### PR TITLE
Add proxy support for TMDb service

### DIFF
--- a/api_service/automate_process.py
+++ b/api_service/automate_process.py
@@ -1,3 +1,5 @@
+import traceback
+
 from api_service.config.config import load_env_vars
 from api_service.config.logger_manager import LoggerManager
 from api_service.handler.jellyfin_handler import JellyfinHandler
@@ -62,7 +64,7 @@ class ContentAutomation:
         instance.logger.info(f"Configuration: service={instance.selected_service}, max_content={instance.max_content}, "
                            f"max_similar_movie={instance.max_similar_movie}, max_similar_tv={instance.max_similar_tv}")
         instance.logger.debug(f"Selected users: {instance.selected_users}")
-        
+
         # TMDB filters
         tmdb_threshold = int(env_vars.get('FILTER_TMDB_THRESHOLD') or 60)
         tmdb_min_votes = int(env_vars.get('FILTER_TMDB_MIN_VOTES') or 20)
@@ -111,7 +113,8 @@ class ContentAutomation:
             filter_language,
             filter_genre,
             filter_region_provider,
-            filter_streaming_services
+            filter_streaming_services,
+            env_vars['PROXY_URL'],
         )
         instance.logger.info("TMDb client initialized successfully")
 
@@ -170,4 +173,7 @@ class ContentAutomation:
             self.logger.info("Content automation process completed successfully")
         except Exception as e:
             self.logger.error(f"Content automation process failed: {str(e)}")
+            tb = e.__traceback__
+            exception_text = ''.join(traceback.format_exception(type(e), e, tb))
+            self.logger.debug(f"Content automation process on fail traceback: {exception_text}")
             raise

--- a/api_service/config/config.py
+++ b/api_service/config/config.py
@@ -73,6 +73,7 @@ def get_default_values():
     logger.debug("Getting default values for environment variables")
     return {
         'TMDB_API_KEY': lambda: '',
+        'PROXY_URL': lambda: None,
         'JELLYFIN_API_URL': lambda: '',
         'JELLYFIN_TOKEN': lambda: '',
         'SEER_API_URL': lambda: '',
@@ -165,10 +166,10 @@ def save_env_vars(config_data):
 
         # Reload environment variables after saving
         load_env_vars()
-        
+
         # Update the cron job
         start_cron_job(env_vars)
-        
+
     except Exception as e:
         logger.error(f"Error saving environment variables: {e}")
         raise
@@ -205,11 +206,11 @@ def get_config_sections():
     return {
         'general': ['MAX_SIMILAR_MOVIE', 'MAX_SIMILAR_TV', 'CRON_TIMES', 'MAX_CONTENT_CHECKS',
                    'SEARCH_SIZE', 'SUBPATH', 'LOG_LEVEL'],
-        'services': ['TMDB_API_KEY', 'SELECTED_SERVICE', 'PLEX_TOKEN', 'PLEX_API_URL',
+        'services': ['TMDB_API_KEY', 'PROXY_URL', 'SELECTED_SERVICE', 'PLEX_TOKEN', 'PLEX_API_URL',
                     'PLEX_LIBRARIES', 'JELLYFIN_API_URL', 'JELLYFIN_TOKEN', 'JELLYFIN_LIBRARIES',
                     'SEER_API_URL', 'SEER_TOKEN', 'SEER_USER_NAME', 'SEER_SESSION_TOKEN'],
         'database': ['DB_TYPE', 'DB_HOST', 'DB_PORT', 'DB_USER', 'DB_PASSWORD', 'DB_NAME',
-                    'DB_MIN_CONNECTIONS', 'DB_MAX_CONNECTIONS', 'DB_MAX_IDLE_TIME', 
+                    'DB_MIN_CONNECTIONS', 'DB_MAX_CONNECTIONS', 'DB_MAX_IDLE_TIME',
                     'DB_MAX_LIFETIME', 'DB_CONNECTION_TIMEOUT', 'DB_RETRY_ATTEMPTS', 'DB_RETRY_DELAY'],
         'content_filters': ['FILTER_TMDB_THRESHOLD', 'FILTER_TMDB_MIN_VOTES', 'FILTER_GENRES_EXCLUDE',
                            'HONOR_JELLYSEER_DISCOVERY', 'FILTER_RELEASE_YEAR', 'FILTER_INCLUDE_NO_RATING',

--- a/client/src/components/DashboardPage.vue
+++ b/client/src/components/DashboardPage.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="settings-container">
-    <div 
-      class="background-layer current-bg" 
+    <div
+      class="background-layer current-bg"
       :style="{ backgroundImage: 'url(' + currentBackgroundUrl + ')' }"
       :class="{ 'fade-out': isTransitioning }"
     ></div>
-    <div 
-      class="background-layer next-bg" 
+    <div
+      class="background-layer next-bg"
       :style="{ backgroundImage: 'url(' + nextBackgroundUrl + ')' }"
       :class="{ 'fade-in': isTransitioning }"
     ></div>
@@ -42,7 +42,7 @@
       <!-- Mobile Navigation -->
       <div class="mobile-nav">
         <div class="mobile-tab-selector">
-          <button 
+          <button
             @click="showMobileDropdown = !showMobileDropdown"
             class="mobile-dropdown-button"
             :class="{ active: showMobileDropdown }"
@@ -55,7 +55,7 @@
             </span>
             <i class="fas fa-chevron-down dropdown-arrow" :class="{ rotated: showMobileDropdown }"></i>
           </button>
-          
+
           <transition name="dropdown-slide">
             <div v-if="showMobileDropdown" class="mobile-dropdown">
               <button
@@ -96,8 +96,8 @@
       <!-- Action Footer -->
       <div class="settings-footer">
         <div class="footer-info">
-          <button 
-                @click="showChangelog" 
+          <button
+                @click="showChangelog"
                 class="changelog-btn"
                 title="View changelog for current version"
               >
@@ -106,15 +106,15 @@
           <div class="version-info">
             <div class="version-text-container">
               <span>SuggestArr {{ currentVersion }}</span>
-              <span 
-                v-if="currentImageTag === 'nightly'" 
+              <span
+                v-if="currentImageTag === 'nightly'"
                 class="nightly-badge"
               >
                 ({{ currentImageTag }})
               </span>
             </div>
-            <button 
-              @click="checkForUpdates" 
+            <button
+              @click="checkForUpdates"
               :disabled="updateAvailable === null"
               class="version-check-btn"
               :class="{ 'update-available': updateAvailable }"
@@ -125,7 +125,7 @@
             </button>
           </div>
         </div>
-        
+
         <div class="footer-actions">
           <button
             @click="exportConfig"
@@ -135,7 +135,7 @@
             <i class="fas fa-download"></i>
             <span>Export</span>
           </button>
-          
+
           <button
             @click="importConfig"
             class="btn btn-outline"
@@ -144,7 +144,7 @@
             <i class="fas fa-upload"></i>
             <span>Import</span>
           </button>
-          
+
           <button
             @click="resetConfig"
             class="btn btn-danger"
@@ -153,7 +153,7 @@
             <i class="fas fa-undo"></i>
             <span>Reset</span>
           </button>
-          
+
           <button
             @click="forceRunAutomation"
             class="btn btn-secondary"
@@ -183,19 +183,19 @@
               <i class="fab fa-github changelog-icon"></i>
               <h3>Changelog - {{ currentVersion }}</h3>
             </div>
-            
+
             <div class="modal-body changelog-body">
               <div v-if="isLoadingChangelog" class="changelog-loading">
                 <i class="fas fa-spinner fa-spin"></i>
                 <span>Loading changelog...</span>
               </div>
-              
+
               <div v-else-if="changelogError" class="changelog-error">
                 <i class="fas fa-exclamation-triangle"></i>
                 <span>{{ changelogError }}</span>
                 <button @click="showChangelog" class="btn btn-secondary btn-sm">Retry</button>
               </div>
-              
+
               <div v-else class="changelog-content">
                 <div v-if="changelogData" v-html="changelogData"></div>
                 <div v-else class="no-changelog">
@@ -204,11 +204,11 @@
                 </div>
               </div>
             </div>
-            
+
             <div class="modal-actions">
-              <a 
-                :href="`https://github.com/giuseppe99barchetta/SuggestArr/releases/tag/${currentVersion}`" 
-                target="_blank" 
+              <a
+                :href="`https://github.com/giuseppe99barchetta/SuggestArr/releases/tag/${currentVersion}`"
+                target="_blank"
                 class="btn btn-outline"
                 v-if="changelogData"
               >
@@ -241,19 +241,19 @@
               <i class="fas fa-exclamation-triangle warning-icon"></i>
               <h3>Confirm Reset</h3>
             </div>
-            
+
             <p class="modal-body">
-              Are you sure you want to reset all settings to default? 
+              Are you sure you want to reset all settings to default?
               <strong>This action cannot be undone</strong> and will:
             </p>
-            
+
             <ul class="reset-warning-list">
               <li><i class="fas fa-times-circle"></i> Clear all service connections</li>
               <li><i class="fas fa-times-circle"></i> Remove all custom filters</li>
               <li><i class="fas fa-times-circle"></i> Reset scheduling preferences</li>
               <li><i class="fas fa-times-circle"></i> Clear database configuration</li>
             </ul>
-            
+
             <div class="modal-actions">
               <button @click="showResetModal = false" class="btn btn-secondary">
                 <i class="fas fa-times"></i>
@@ -304,7 +304,7 @@ export default {
   setup() {
     const { currentBackgroundUrl, nextBackgroundUrl, isTransitioning, startDefaultImageRotation, startBackgroundImageRotation, stopBackgroundImageRotation } = useBackgroundImage();
     const { currentVersion, currentImageTag, currentBuildDate, updateAvailable, checkForUpdates } = useVersionCheck();
-    
+
     return {
       currentBackgroundUrl,
       nextBackgroundUrl,
@@ -379,9 +379,9 @@ export default {
   async mounted() {
     try {
       await this.loadConfig();
-      
+
       this.loadRequestCount();
-      
+
       if (this.config.TMDB_API_KEY) {
         this.startBackgroundImageRotation(this.config.TMDB_API_KEY);
       }
@@ -446,13 +446,13 @@ export default {
     async showChangelog() {
       this.showChangelogModal = true;
       this.changelogError = null;
-      
+
       if (!this.changelogData) {
         this.isLoadingChangelog = true;
         try {
           // Get release info from GitHub API
           const response = await axios.get(`https://api.github.com/repos/giuseppe99barchetta/SuggestArr/releases/tags/${this.currentVersion}`);
-          
+
           if (response.data && response.data.body) {
             // Convert markdown to basic HTML
             this.changelogData = this.parseMarkdown(response.data.body);
@@ -470,7 +470,7 @@ export default {
 
     parseMarkdown(markdown) {
       if (!markdown) return '';
-      
+
       // Basic markdown to HTML conversion
       return markdown
         // Headers
@@ -517,15 +517,15 @@ export default {
     },
     async testConnection(service, config) {
       this.testingConnections[service] = true;
-    
+
       try {
         let endpoint = '';
         let payload = {};
-      
+
         switch (service) {
           case 'tmdb':
             endpoint = '/api/tmdb/test';
-            payload = { api_key: config.api_key };
+            payload = { api_key: config.api_key, proxy: config.proxy };
             break;
           case 'plex':
             endpoint = '/api/plex/test';
@@ -533,23 +533,23 @@ export default {
             break;
           case 'jellyfin':
             endpoint = '/api/jellyfin/test';
-            payload = { 
+            payload = {
               api_url: config.api_url,
-              token: config.token 
+              token: config.token
             };
             break;
           case 'emby':
             endpoint = '/api/jellyfin/test';
-            payload = { 
+            payload = {
               api_url: config.api_url,
-              token: config.token 
+              token: config.token
             };
             break;
           case 'seer':
             endpoint = '/api/seer/test';
-            payload = { 
-              api_url: config.api_url, 
-              token: config.token 
+            payload = {
+              api_url: config.api_url,
+              token: config.token
             };
             break;
           case 'database':
@@ -566,9 +566,9 @@ export default {
           default:
             throw new Error('Unknown service');
         }
-      
+
         const response = await axios.post(endpoint, payload);
-      
+
         if (this.$toast) {
           this.$toast.success(
             response.data.message || `${service.toUpperCase()} connection successful!`,
@@ -580,18 +580,18 @@ export default {
         } else {
           alert(response.data.message || `${service.toUpperCase()} connection successful!`);
         }
-      
+
         return response.data;
-      
+
       } catch (error) {
         console.error(`${service} connection test failed:`, error);
-      
+
         let errorMessage = 'Connection test failed';
-      
+
         if (error.response) {
           const status = error.response.status;
           const data = error.response.data;
-        
+
           if (status === 400) {
             errorMessage = data?.message || 'Invalid credentials or server unreachable. Please check your URL and token.';
           } else if (status === 401) {
@@ -610,7 +610,7 @@ export default {
         } else {
           errorMessage = error.message || 'Request configuration error';
         }
-      
+
         if (this.$toast) {
           this.$toast.error(errorMessage, {
             position: 'top-right',
@@ -619,12 +619,12 @@ export default {
         } else {
           alert(`Error: ${errorMessage}`);
         }
-      
+
         return {
           status: 'error',
           message: errorMessage
         };
-      
+
       } finally {
         this.testingConnections[service] = false;
       }
@@ -632,10 +632,10 @@ export default {
     getServiceStatus() {
       const service = this.config.SELECTED_SERVICE;
       if (!service) return 'status-disconnected';
-      
+
       if (service === 'plex' && this.config.PLEX_TOKEN) return 'status-connected';
       if ((service === 'jellyfin' || service === 'emby') && this.config.JELLYFIN_TOKEN) return 'status-connected';
-      
+
       return 'status-warning';
     },
 
@@ -698,7 +698,7 @@ export default {
 
       this.loadingMessage = 'Importing configuration...';
       this.isLoading = true;
-      
+
       try {
         const text = await file.text();
         const configData = JSON.parse(text);

--- a/client/src/components/settings/SettingsServices.vue
+++ b/client/src/components/settings/SettingsServices.vue
@@ -46,6 +46,34 @@
         </div>
 
         <div class="form-group">
+          <label for="proxyUrl">Proxy url</label>
+          <div class="input-group">
+            <input
+              id="proxyUrl"
+              v-model="localConfig.PROXY_URL"
+              :type="showProxyUrl ? 'text' : 'password'"
+              placeholder="Leave blank for direct connection"
+              class="form-control"
+              :disabled="isLoading"
+            />
+            <button
+              @click="showProxyUrl = !showProxyUrl"
+              type="button"
+              class="btn btn-outline btn-sm"
+              :disabled="isLoading"
+            >
+              <i :class="showProxyUrl ? 'fas fa-eye-slash' : 'fas fa-eye'"></i>
+            </button>
+          </div>
+          <small class="form-help">
+            If you are experiencing issues accessing the TMDB API, you can use a proxy to bypass the block.
+            Please note that only HTTP and HTTPS proxies are supported. Example of a connection string for
+            a proxy requiring authentication:<br>
+            https://user:password@your_proxy.org:3128.
+          </small>
+        </div>
+
+        <div class="form-group">
           <button
             @click="testTmdbConnection"
             class="btn btn-outline form-group-button"
@@ -306,6 +334,7 @@ export default {
       localConfig: {},
       originalConfig: {},
       showTmdbKey: false,
+      showProxyUrl: false,
       showPlexToken: false,
       showJellyfinToken: false,
       showSeerToken: false,
@@ -329,39 +358,39 @@ export default {
     getMediaServerStatus() {
       const service = this.localConfig.SELECTED_SERVICE;
       if (!service) return 'status-disconnected';
-      
+
       if (service === 'plex' && this.localConfig.PLEX_TOKEN && this.localConfig.PLEX_API_URL) {
         return 'status-connected';
       }
-      if ((service === 'jellyfin' || service === 'emby') && 
+      if ((service === 'jellyfin' || service === 'emby') &&
           this.localConfig.JELLYFIN_TOKEN && this.localConfig.JELLYFIN_API_URL) {
         return 'status-connected';
       }
-      
+
       return 'status-warning';
     },
     getMediaServerStatusText() {
       const service = this.localConfig.SELECTED_SERVICE;
       if (!service) return 'No Service Selected';
-      
+
       if (service === 'plex' && this.localConfig.PLEX_TOKEN && this.localConfig.PLEX_API_URL) {
         return 'Connected';
       }
-      if ((service === 'jellyfin' || service === 'emby') && 
+      if ((service === 'jellyfin' || service === 'emby') &&
           this.localConfig.JELLYFIN_TOKEN && this.localConfig.JELLYFIN_API_URL) {
         return 'Connected';
       }
-      
+
       return 'Incomplete Configuration';
     },
     getSeerStatus() {
-      return (this.localConfig.SEER_API_URL && this.localConfig.SEER_TOKEN) 
-        ? 'status-connected' 
+      return (this.localConfig.SEER_API_URL && this.localConfig.SEER_TOKEN)
+        ? 'status-connected'
         : 'status-disconnected';
     },
     getSeerStatusText() {
-      return (this.localConfig.SEER_API_URL && this.localConfig.SEER_TOKEN) 
-        ? 'Connected' 
+      return (this.localConfig.SEER_API_URL && this.localConfig.SEER_TOKEN)
+        ? 'Connected'
         : 'Disconnected';
     },
   },
@@ -375,16 +404,6 @@ export default {
     },
   },
   methods: {
-    async testTmdbConnection() {
-      try {
-        await this.$emit('test-connection', 'tmdb', {
-          api_key: this.localConfig.TMDB_API_KEY,
-        });
-      } catch (error) {
-        console.error('Error testing TMDB connection:', error);
-      }
-    },
-
     async testJellyfinConnection() {
       if (!this.localConfig.JELLYFIN_API_URL) {
         if (this.$toast) {
@@ -395,7 +414,7 @@ export default {
         }
         return;
       }
-    
+
       if (!this.localConfig.JELLYFIN_TOKEN) {
         if (this.$toast) {
           this.$toast.warning('Please enter a Jellyfin API token', {
@@ -405,7 +424,7 @@ export default {
         }
         return;
       }
-    
+
       try {
         const url = this.localConfig.JELLYFIN_API_URL.trim();
         const testUrl = url.startsWith('http') ? url : `http://${url}`;
@@ -419,7 +438,7 @@ export default {
         }
         return;
       }
-    
+
       await this.$emit('test-connection', 'jellyfin', {
         api_url: this.localConfig.JELLYFIN_API_URL.trim(),
         token: this.localConfig.JELLYFIN_TOKEN.trim(),
@@ -436,7 +455,7 @@ export default {
         }
         return;
       }
-    
+
       if (!this.localConfig.PLEX_TOKEN) {
         if (this.$toast) {
           this.$toast.warning('Please enter a Plex token', {
@@ -446,7 +465,7 @@ export default {
         }
         return;
       }
-    
+
       try {
         const url = this.localConfig.PLEX_API_URL.trim();
         const testUrl = url.startsWith('http') ? url : `http://${url}`;
@@ -460,7 +479,7 @@ export default {
         }
         return;
       }
-    
+
       await this.$emit('test-connection', 'plex', {
         token: this.localConfig.PLEX_TOKEN.trim(),
         api_url: this.localConfig.PLEX_API_URL.trim(),
@@ -477,9 +496,10 @@ export default {
         }
         return;
       }
-    
+
       await this.$emit('test-connection', 'tmdb', {
         api_key: this.localConfig.TMDB_API_KEY.trim(),
+        proxy: this.localConfig.PROXY_URL.trim(),
       });
     },
 
@@ -493,7 +513,7 @@ export default {
         }
         return;
       }
-    
+
       if (!this.localConfig.SEER_TOKEN) {
         if (this.$toast) {
           this.$toast.warning('Please enter an API token', {
@@ -503,7 +523,7 @@ export default {
         }
         return;
       }
-    
+
       try {
         const url = this.localConfig.SEER_API_URL.trim();
         const testUrl = url.startsWith('http') ? url : `http://${url}`;
@@ -517,7 +537,7 @@ export default {
         }
         return;
       }
-    
+
       await this.$emit('test-connection', 'seer', {
         api_url: this.localConfig.SEER_API_URL.trim(),
         token: this.localConfig.SEER_TOKEN.trim(),
@@ -528,6 +548,7 @@ export default {
       try {
         const dataToSave = {
           TMDB_API_KEY: this.localConfig.TMDB_API_KEY,
+          PROXY_URL: this.localConfig.PROXY_URL,
           SELECTED_SERVICE: this.localConfig.SELECTED_SERVICE,
         };
 
@@ -567,6 +588,7 @@ export default {
     async resetToDefaults() {
       const defaults = {
         TMDB_API_KEY: '',
+        PROXY_URL: null,
         SELECTED_SERVICE: '',
         PLEX_TOKEN: '',
         PLEX_API_URL: '',


### PR DESCRIPTION
The Movie Database (TMDb) actively blocks API and website access from Russia and Belarus. Access from other countries, notably China and India, is often blocked by local Internet Service Providers (ISPs) or government firewalls. One way to bypass blocks is to use a proxy.

This PR updates TMDb requests to support proxy usage. It also includes minor improvements to the search for movies missing a TMDb ID (tested for Jellyfin only). I also suggest continuing this work by moving all TMDB API requests to the backend with proxy support.