### PR TITLE
fix: Stop TMDB API polling when not configured

### DIFF
--- a/client/src/composables/useBackgroundImage.js
+++ b/client/src/composables/useBackgroundImage.js
@@ -63,9 +63,14 @@ export function useBackgroundImage() {
       const imageUrl = await fetchRandomMovieImage();
       if (imageUrl) {
         await changeBackground(imageUrl);
+      } else if (imageUrl === null) {
+        // Stop polling TMDB if it is not configured or fails repeatedly
+        console.warn("TMDB not configured or no image, falling back to default rotation.");
+        startDefaultImageRotation();
       }
     } catch (error) {
       console.error("Background rotation error:", error);
+      startDefaultImageRotation();
     }
   }
 


### PR DESCRIPTION
## Fix: Stop TMDB API polling when not configured (Fixes 400 Bad Request log spam)

### Description
Resolves an issue where the frontend would continuously poll the `/api/tmdb/popular` endpoint every 10 seconds for background images, even if a TMDB API key was not yet configured. This resulted in the backend spamming the logs with `400 Bad Request` messages.

### Changes
- Updated [fetchRandomMovieImageAsync] in [useBackgroundImage.js] to correctly handle `null` responses (which occur when the backend returns a `400` because TMDB is not configured).
- The background rotation will now gracefully fallback to rotating local default images (`default1.jpg`, `default2.jpg`, `default3.jpg`) instead of endlessly retrying the failed endpoint.
