### PR TITLE
feat: Publish Docker images to GitHub registry

### DIFF
--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -108,6 +108,13 @@ jobs:
           username: ciuse99
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Login to ghcr.io
+        uses: docker/login-action@v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Prepare platform slug
         id: prep
         run: echo "platform_slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> $GITHUB_OUTPUT
@@ -119,7 +126,9 @@ jobs:
           file: docker/Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ciuse99/suggestarr:${{ needs.bump-version.outputs.new_version }}-${{ steps.prep.outputs.platform_slug }}
+          tags: |
+            ciuse99/suggestarr:${{ needs.bump-version.outputs.new_version }}-${{ steps.prep.outputs.platform_slug }}
+            ghcr.io/giuseppe99barchetta/suggestarr:${{ needs.bump-version.outputs.new_version }}-${{ steps.prep.outputs.platform_slug }}
           cache-from: |
             type=gha,scope=prod-${{ matrix.platform }}
             type=registry,ref=ciuse99/suggestarr:cache

--- a/.github/workflows/docker_hub_build_nightly.yml
+++ b/.github/workflows/docker_hub_build_nightly.yml
@@ -33,6 +33,13 @@ jobs:
           username: ciuse99
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Login to ghcr.io
+        uses: docker/login-action@v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Prepare platform slug
         id: prep
         run: echo "platform_slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> $GITHUB_OUTPUT
@@ -44,7 +51,9 @@ jobs:
           file: docker/Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ciuse99/suggestarr:nightly-${{ steps.prep.outputs.platform_slug }}
+          tags: |
+            ciuse99/suggestarr:nightly-${{ steps.prep.outputs.platform_slug }}
+            ghcr.io/giuseppe99barchetta/suggestarr:nightly-${{ steps.prep.outputs.platform_slug }}
           cache-from: |
             type=gha,scope=nightly-${{ matrix.platform }}
             type=registry,ref=ciuse99/suggestarr:cache


### PR DESCRIPTION
## Summary

This will push the Docker image to ghcr.io in addition to DockerHub.

This is better for free and unauthenticated users that are heavily rate-limited: https://docs.docker.com/docker-hub/usage/

## Checklist

- [ ] Tests added/updated when applicable
- [ ] Documentation updated when behavior or setup changed
- [ ] No hardcoded styles introduced
