### PR TITLE
feat: Add configuration option to include adult content in TMDB searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
       # Optional: Customize the port (defaults to 5000 if not set)
       - SUGGESTARR_PORT=${SUGGESTARR_PORT:-5000}
+      # Optional: Set to true to include adult content in TMDB searches (defaults to false)
+      - INCLUDE_ADULT=${INCLUDE_ADULT:-false}
 ```
 To start the container with Docker Compose:
 

--- a/api_service/blueprints/tmdb/routes.py
+++ b/api_service/blueprints/tmdb/routes.py
@@ -1,3 +1,4 @@
+import os
 import time
 from flask import Blueprint, request, jsonify
 import aiohttp
@@ -160,7 +161,9 @@ def get_popular_movies():
         502 if TMDB upstream returns an error.
     """
     page          = request.args.get('page', 1, type=int)
-    include_adult = request.args.get('include_adult', 'false')
+    env_vars      = load_env_vars()
+    include_adult_default = str(env_vars.get('INCLUDE_ADULT', False)).lower()
+    include_adult = request.args.get('include_adult', include_adult_default)
     cache_key     = f'popular:{page}:{include_adult}'
 
     cached = _cache_get(cache_key, _POPULAR_TTL)

--- a/api_service/config/config.py
+++ b/api_service/config/config.py
@@ -187,6 +187,7 @@ def get_default_values():
         # Include pay-per-view availability (rent/buy) in streaming checks
         # Default: false (only subscription-based flatrate providers are considered)
         'FILTER_INCLUDE_TVOD': lambda: False,
+        'INCLUDE_ADULT': lambda: False,
         'SUBPATH': lambda: None,
         'DB_TYPE': lambda: 'sqlite',
         'DB_HOST': lambda: None,
@@ -333,7 +334,7 @@ def get_config_sections():
                      'ENABLE_STATIC_BACKGROUND', 'STATIC_BACKGROUND_COLOR',
                      'CACHE_TTL', 'MAX_CACHE_SIZE', 'API_TIMEOUT', 'API_RETRIES',
                      'ENABLE_API_CACHING', 'OPENAI_API_KEY', 'OPENAI_BASE_URL',
-                     'LLM_MODEL', 'SUBPATH', 'ALLOW_REGISTRATION',
+                     'LLM_MODEL', 'SUBPATH', 'ALLOW_REGISTRATION', 'INCLUDE_ADULT',
                      'AUTH_MODE', 'AUTH_TRUSTED_CIDRS', 'AUTH_BYPASS_USERNAME']
     }
 

--- a/api_service/services/tmdb/tmdb_discover.py
+++ b/api_service/services/tmdb/tmdb_discover.py
@@ -4,9 +4,11 @@ Provides functionality to discover movies and TV shows using various filter crit
 """
 import aiohttp
 import asyncio
+import os
 from typing import Any, Dict, List, Optional
 
 from api_service.config.logger_manager import LoggerManager
+from api_service.config.config import load_env_vars
 from api_service.services.filter_normalization import build_tmdb_params, normalize_filters
 
 # Constants
@@ -445,7 +447,9 @@ class TMDbDiscover:
 
         # Default to exclude adult content
         if 'include_adult' not in params:
-            params['include_adult'] = 'false'
+            env_vars = load_env_vars()
+            include_adult_val = str(env_vars.get('INCLUDE_ADULT', False)).lower()
+            params['include_adult'] = include_adult_val
 
         self.logger.debug(f"Built query params: {params}")
         return params

--- a/api_service/test/test_config.py
+++ b/api_service/test/test_config.py
@@ -91,6 +91,7 @@ class TestConfig(unittest.TestCase):
         "SEER_REQUEST_DELAY": 0.5,
         "FILTER_INCLUDE_TVOD": "false",
         "ALLOW_REGISTRATION": False,
+        "INCLUDE_ADULT": False,
     }
 
     def setUp(self):

--- a/api_service/test/test_cron.py
+++ b/api_service/test/test_cron.py
@@ -174,7 +174,7 @@ class TestJobManagerCronTrigger(unittest.TestCase):
     def test_preset_every_hour(self):
         trigger = self.manager._preset_to_trigger('every_hour')
         self.assertIsInstance(trigger, CronTrigger)
-        now = datetime(2026, 2, 15, 1, 30, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 2, 15, 1, 14, 0, tzinfo=timezone.utc)
         nxt = _next_fire(trigger, now)
         # Next fire must always land on the top of the hour
         self.assertEqual(nxt.minute, 0)

--- a/api_service/test/test_tmdb_discover.py
+++ b/api_service/test/test_tmdb_discover.py
@@ -14,6 +14,7 @@ Covers:
 """
 
 import asyncio
+import os
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -100,9 +101,17 @@ class TestBuildQueryParams(unittest.TestCase):
         params = self.disc._build_query_params({'sort_by': 'vote_average.desc'})
         self.assertEqual(params['sort_by'], 'vote_average.desc')
 
-    def test_default_include_adult_is_false(self):
+    @patch('api_service.services.tmdb.tmdb_discover.load_env_vars')
+    def test_default_include_adult_is_false(self, mock_load_env_vars):
+        mock_load_env_vars.return_value = {}
         params = self.disc._build_query_params({})
         self.assertEqual(params['include_adult'], 'false')
+
+    @patch('api_service.services.tmdb.tmdb_discover.load_env_vars')
+    def test_default_include_adult_is_true_via_env(self, mock_load_env_vars):
+        mock_load_env_vars.return_value = {'INCLUDE_ADULT': True}
+        params = self.disc._build_query_params({})
+        self.assertEqual(params['include_adult'], 'true')
 
     def test_internal_imdb_keys_not_in_output(self):
         params = self.disc._build_query_params({

--- a/client/src/api/tmdbApi.js
+++ b/client/src/api/tmdbApi.js
@@ -18,7 +18,7 @@ export const fetchRandomMovieImage = async () => {
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       const response = await axios.get('/api/tmdb/popular', {
-        params: { page: randomPage, include_adult: false },
+        params: { page: randomPage },
         timeout: 10000,
       });
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - SUGGESTARR_PORT=${SUGGESTARR_PORT:-5000}
       - TZ=Europe/Rome
+      - INCLUDE_ADULT=${INCLUDE_ADULT:-false}


### PR DESCRIPTION
## Summary

This pull request introduces the `INCLUDE_ADULT` configuration option to control whether adult content is included in TMDB searches by default. The variable defaults to `false` if not set, maintaining the original behavior.

Changes include:
- Adding `INCLUDE_ADULT` to the backend configuration schema (`api_service/config/config.py`).
- Updating the TMDB service (`api_service/services/tmdb/tmdb_discover.py`) and routes (`api_service/blueprints/tmdb/routes.py`) to respect this global configuration.
- Modifying the frontend (`client/src/api/tmdbApi.js`) to omit its hardcoded `include_adult` parameter, allowing the backend to dictate the default behavior.
- Adding tests to verify the new behavior, and fixing a local timezone-related edge case in `test_cron.py`.
- Documenting the new environment variable in `docker/docker-compose.yml` and `README.md`.

## Checklist

- [x] Tests added/updated when applicable
- [x] Documentation updated when behavior or setup changed
- [x] No hardcoded styles introduced