### PR TITLE
Optimize TMDB detail and OMDB API calls

### DIFF
--- a/api_service/services/tmdb/tmdb_client.py
+++ b/api_service/services/tmdb/tmdb_client.py
@@ -81,24 +81,69 @@ class TMDbClient(BaseHTTPClient):
                 self.logger.debug("No data returned for page %d", page)
                 break
 
+            # First pass: identify items that need detail calls
+            items_to_process = []
             for item in data['results']:
                 filter_result = self._apply_filters(item, content_type)
                 core_passed = filter_result['passed']
 
-                # In normal mode skip failing items early (no detail API calls wasted)
+                # In normal mode skip failing items early
                 if not dry_run and not core_passed:
                     continue
 
-                needs_detail_call = self.filter_min_runtime or self.rating_source in ('imdb', 'both')
+                items_to_process.append((item, filter_result, core_passed))
+
+            # Fetch details concurrently
+            needs_detail_call = self.filter_min_runtime or self.rating_source in ('imdb', 'both')
+            detail_results = {}
+
+            if needs_detail_call and items_to_process:
+                # Use a semaphore to prevent too many concurrent requests to TMDB
+                sem = asyncio.Semaphore(10)
+
+                async def fetch_details(item_id, item_type):
+                    async with sem:
+                        return item_id, await self._get_item_details(item_id, item_type)
+
+                tasks = []
+                for item, _, core_passed in items_to_process:
+                    if core_passed or dry_run:
+                        tasks.append(fetch_details(item['id'], content_type))
+
+                if tasks:
+                    results = await asyncio.gather(*tasks)
+                    detail_results = {item_id: details for item_id, details in results}
+
+            # Now fetch OMDB ratings concurrently if needed
+            imdb_results = {}
+            if self.rating_source in ('imdb', 'both') and self.omdb_client and items_to_process:
+                omdb_sem = asyncio.Semaphore(10)
+
+                async def fetch_omdb(imdb_id):
+                    async with omdb_sem:
+                        return imdb_id, await self.omdb_client.get_rating(imdb_id)
+
+                omdb_tasks = []
+                for item, _, core_passed in items_to_process:
+                    if core_passed or dry_run:
+                        details = detail_results.get(item['id']) or {}
+                        imdb_id = details.get('imdb_id')
+                        if imdb_id:
+                            omdb_tasks.append(fetch_omdb(imdb_id))
+
+                if omdb_tasks:
+                    results = await asyncio.gather(*omdb_tasks)
+                    imdb_results = {imdb_id: data for imdb_id, data in results}
+
+            # Second pass: apply final filters with fetched data
+            for item, filter_result, core_passed in items_to_process:
                 runtime = None
                 imdb_id = None
 
-                # Only make detail API calls when the item passes core filters or we're in
-                # dry-run mode (so we can show runtime/IMDB results for passing items).
                 if needs_detail_call and (core_passed or dry_run):
-                    details = await self._get_item_details(item['id'], content_type)
-                    runtime = details.get('runtime') if details else None
-                    imdb_id = details.get('imdb_id') if details else None
+                    details = detail_results.get(item['id']) or {}
+                    runtime = details.get('runtime')
+                    imdb_id = details.get('imdb_id')
 
                 # Runtime check
                 if self.filter_min_runtime:
@@ -125,7 +170,7 @@ class TMDbClient(BaseHTTPClient):
                 # IMDB rating check
                 if self.rating_source in ('imdb', 'both') and self.omdb_client:
                     if imdb_id:
-                        imdb_data = await self.omdb_client.get_rating(imdb_id)
+                        imdb_data = imdb_results.get(imdb_id)
                         if dry_run:
                             imdb_result = self._get_imdb_filter_result(imdb_data)
                             filter_result['imdb_rating'] = imdb_result

--- a/api_service/services/tmdb/tmdb_discover.py
+++ b/api_service/services/tmdb/tmdb_discover.py
@@ -131,11 +131,41 @@ class TMDbDiscover:
                 self.logger.warning(f"No data returned for page {page}")
                 break
 
-            for item in data['results']:
-                if use_imdb:
-                    imdb_id = await self._get_imdb_id(item['id'], media_type)
+            items_to_process = data['results']
+
+            if use_imdb and items_to_process:
+                # 1. Fetch IMDB IDs concurrently
+                id_sem = asyncio.Semaphore(10)
+                async def fetch_id(item):
+                    async with id_sem:
+                        return item['id'], await self._get_imdb_id(item['id'], media_type)
+
+                id_tasks = [fetch_id(item) for item in items_to_process]
+                id_results = await asyncio.gather(*id_tasks)
+                imdb_ids = dict(id_results)
+
+                # 2. Fetch OMDB ratings concurrently
+                omdb_sem = asyncio.Semaphore(10)
+                async def fetch_omdb(imdb_id):
+                    async with omdb_sem:
+                        return imdb_id, await self.omdb_client.get_rating(imdb_id)
+
+                omdb_tasks = [
+                    fetch_omdb(imdb_id)
+                    for _, imdb_id in imdb_ids.items() if imdb_id
+                ]
+
+                imdb_data_results = {}
+                if omdb_tasks:
+                    omdb_results = await asyncio.gather(*omdb_tasks)
+                    imdb_data_results = dict(omdb_results)
+
+                # 3. Apply IMDB filters
+                filtered_items = []
+                for item in items_to_process:
+                    imdb_id = imdb_ids.get(item['id'])
                     if imdb_id:
-                        imdb_data = await self.omdb_client.get_rating(imdb_id)
+                        imdb_data = imdb_data_results.get(imdb_id)
                         if not self._check_imdb_filter(
                             imdb_data, item, imdb_rating_gte, imdb_min_votes, include_no_rating
                         ):
@@ -145,6 +175,11 @@ class TMDbDiscover:
                         self.logger.debug("Excluding %s: no IMDB ID found in TMDB data", title)
                         continue
 
+                    filtered_items.append(item)
+
+                items_to_process = filtered_items
+
+            for item in items_to_process:
                 formatted = self._format_result(item, media_type)
                 results.append(formatted)
 


### PR DESCRIPTION
💡 What: Replaced sequential (N+1) API calls in `tmdb_client.py` and `tmdb_discover.py` with concurrent batched calls using `asyncio.gather` and `asyncio.Semaphore(10)`.

🎯 Why: During pagination in TMDB API calls, fetching item details (like runtime or IMDB IDs) and then querying OMDB for ratings for each item individually created an N+1 query problem, severely throttling the speed of discovery and recommendations.

📊 Impact: The change significantly improves throughput per fetched page, potentially reducing fetch times by up to 10x depending on the number of candidates needing detail inspection, all while staying within safe API rate limits using a semaphore.

🔬 Measurement: Check the execution time of the `/api/ai_search/` or any TMDB recommendation endpoint when filtering with `filter_min_runtime` or `rating_source` = 'imdb'. Ensure it returns correctly and noticeably faster. All tests pass successfully.

---
*PR created automatically by Jules for task [7467073052090907079](https://jules.google.com/task/7467073052090907079) started by @giuseppe99barchetta*