### PR TITLE
Fix: Missing load_env_vars import in TMDB routes

### DIFF
--- a/api_service/blueprints/tmdb/routes.py
+++ b/api_service/blueprints/tmdb/routes.py
@@ -2,6 +2,7 @@ import os
 import time
 from flask import Blueprint, request, jsonify
 import aiohttp
+from api_service.config.config import load_env_vars
 from api_service.config.logger_manager import LoggerManager
 from api_service.db.database_manager import DatabaseManager
 


### PR DESCRIPTION
This PR fixes a `NameError: name 'load_env_vars' is not defined` in `api_service/blueprints/tmdb/routes.py` by adding the missing import from `api_service.config.config`.

This resolves the missing import issue introduced in PR #307.