### PR TITLE
fix: fetch SeriesProviderIds from parent series when missing on episode

### DIFF
--- a/api_service/handler/jellyfin_handler.py
+++ b/api_service/handler/jellyfin_handler.py
@@ -158,6 +158,16 @@ class JellyfinHandler(BaseMediaHandler):
         source_tmdb_id = provider_ids.get("Tmdb")
 
         if not source_tmdb_id:
+            self.logger.debug(
+                "SeriesProviderIds missing on episode; fetching series item for SeriesId=%s",
+                series_id,
+            )
+            series_provider_ids = await self.jellyfin_client.get_series_provider_ids(
+                user["id"], series_id
+            )
+            source_tmdb_id = series_provider_ids.get("Tmdb")
+
+        if not source_tmdb_id:
             self.logger.debug("Series skipped: no TMDb ID")
             return
 

--- a/api_service/services/jellyfin/jellyfin_client.py
+++ b/api_service/services/jellyfin/jellyfin_client.py
@@ -311,6 +311,37 @@ class JellyfinClient(BaseHTTPClient):
             return None
 
     
+    async def get_series_provider_ids(self, user_id, series_id):
+        """
+        Fetch provider IDs for a series by its Jellyfin SeriesId.
+        Used as a fallback when episode objects do not include SeriesProviderIds.
+        :param user_id: The Jellyfin user ID.
+        :param series_id: The Jellyfin SeriesId from the episode object.
+        :return: Dict of provider IDs (e.g. {"Tmdb": "12345"}), or empty dict.
+        """
+        url = f"{self.api_url}/Users/{user_id}/Items/{series_id}"
+        params = {"Fields": "ProviderIds"}
+        self.logger.debug(
+            "Fetching series item for SeriesId=%s (user=%s)", series_id, user_id
+        )
+        try:
+            session = await self._get_session()
+            async with session.get(
+                url, headers=self.headers, params=params, timeout=self.REQUEST_TIMEOUT
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return data.get("ProviderIds", {})
+                self.logger.warning(
+                    "Failed to fetch series item SeriesId=%s: HTTP %d",
+                    series_id, response.status,
+                )
+        except aiohttp.ClientError as e:
+            self.logger.error(
+                "Error fetching series item SeriesId=%s: %s", series_id, str(e)
+            )
+        return {}
+
     async def get_libraries(self):
         """
         Retrieves list of library asynchronously.


### PR DESCRIPTION
## Problem

Fixes #291

Jellyfin episode objects do not include `SeriesProviderIds` in the API
response, even when the field is explicitly requested via `Fields=ProviderIds,SeriesProviderIds`.
This caused every TV show to be skipped with the log message:
`Series skipped: no TMDb ID`.

## Root cause

The code in `process_episode()` reads `SeriesProviderIds` directly from
the episode object, which is always empty. The `SeriesId` field (which
points to the parent series) is present but was never used for a lookup.

## Fix

When `SeriesProviderIds` is missing or empty on the episode object, make
a secondary API call to `GET /Users/{userId}/Items/{SeriesId}` to fetch
the parent series item and extract the TMDb ID from its `ProviderIds`.

Edge cases handled:
- `SeriesId` missing on episode → skipped (existing guard)
- Secondary API call returns non-200 → returns empty dict, series skipped gracefully
- Secondary API call throws network error → caught, series skipped gracefully
- TMDb ID still not found after lookup → existing "Series skipped" log fires

## Testing

Verified on a live Jellyfin instance via TrueNAS — TV show suggestions
are now generated correctly after the fix.

---

> **Disclaimer:** Claude Code helped me make the fix for the TV-shows issue.
