### PR TITLE
fix: resolve Jellyfin provider ID issue and improve Seer client handling

### DIFF
--- a/api_service/services/jellyfin/jellyfin_client.py
+++ b/api_service/services/jellyfin/jellyfin_client.py
@@ -322,8 +322,8 @@ class JellyfinClient(BaseHTTPClient):
         if series_id in self._series_provider_ids_cache:
             return self._series_provider_ids_cache[series_id]
 
-        url = f"{self.api_url}/Items/{series_id}"
-        params = {"Fields": "ProviderIds"}
+        url = f"{self.api_url}/Items"
+        params = {"Fields": "ProviderIds", "Ids": series_id}
         self.logger.debug("Requesting series provider IDs for %s", series_id)
 
         try:

--- a/api_service/services/seer/seer_client.py
+++ b/api_service/services/seer/seer_client.py
@@ -85,11 +85,11 @@ class SeerClient(BaseHTTPClient):
     async def _make_request(self, method, endpoint, data=None, use_cookie=False, retries=3, delay=2):
         """Unified API request handling with retry logic and error handling."""
         url = f"{self.api_url}/{endpoint}"
-        headers, cookies = self._get_auth_headers(use_cookie)
-
         for attempt in range(retries):
             self.logger.debug("Attempt %d for request to %s", attempt + 1, url)
-            
+
+            headers, cookies = self._get_auth_headers(use_cookie)
+
             # Use shared session but override headers/cookies for this request
             # since aiohttp allows passing request-level headers/cookies
             session = await self._get_session()
@@ -104,8 +104,13 @@ class SeerClient(BaseHTTPClient):
                         self.logger.error(
                             f"Request to {url} failed with status: {response.status}, {message}"
                         )
-                        # Quota-exceeded errors won't be resolved by re-logging in; abort immediately
-                        if 'quota' in message.lower():
+                        # Quota/permission errors won't be resolved by repeated login attempts.
+                        lower_message = message.lower()
+                        if (
+                            'quota' in lower_message
+                            or 'permission' in lower_message
+                            or 'not authorized' in lower_message
+                        ):
                             return None
                         # Otherwise treat as auth failure and retry with login
                         if attempt < retries - 1:
@@ -406,6 +411,9 @@ class SeerClient(BaseHTTPClient):
             return False
 
         self.logger.debug("Sending Jellyseerr request: %s", data)
+        if not self.session_token and self.username and self.password:
+            await self.login()
+
         response = await self._make_request(
             "POST", "api/v1/request", data=data, use_cookie=bool(self.session_token)
         )

--- a/api_service/test/test_jellyfin_client.py
+++ b/api_service/test/test_jellyfin_client.py
@@ -461,8 +461,8 @@ class TestGetSeriesProviderIds(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, {'Tmdb': '1418'})
         session.get.assert_called_once()
         call = session.get.call_args
-        self.assertEqual(call.args[0], 'http://jellyfin.local/Items/series-1')
-        self.assertEqual(call.kwargs.get('params'), {'Fields': 'ProviderIds'})
+        self.assertEqual(call.args[0], 'http://jellyfin.local/Items')
+        self.assertEqual(call.kwargs.get('params'), {'Fields': 'ProviderIds', 'Ids': 'series-1'})
 
     async def test_uses_cache_for_repeated_series_lookup(self):
         resp = _mock_response(200, {'ProviderIds': {'Tmdb': '1418'}})

--- a/api_service/test/test_seer_client.py
+++ b/api_service/test/test_seer_client.py
@@ -126,6 +126,39 @@ class TestMakeRequest(unittest.IsolatedAsyncioTestCase):
             result = await self.client._make_request('POST', 'api/v1/request', retries=2)
         self.assertIsNone(result)
 
+    async def test_recomputes_cookie_after_login_retry(self):
+        self.client.session_token = 'old-token'
+        first = _mock_response(403, {'message': 'Session expired'})
+        second = _mock_response(201, {'id': 42})
+        session = MagicMock()
+        session.request = MagicMock(side_effect=[first, second])
+
+        async def refresh_login():
+            self.client.session_token = 'new-token'
+
+        with patch.object(self.client, '_get_session', AsyncMock(return_value=session)), \
+             patch.object(self.client, 'login', AsyncMock(side_effect=refresh_login)), \
+             patch('asyncio.sleep', AsyncMock()):
+            result = await self.client._make_request(
+                'POST', 'api/v1/request', use_cookie=True, retries=2
+            )
+
+        self.assertEqual(result, {'id': 42})
+        self.assertEqual(session.request.call_args_list[0].kwargs['cookies']['connect.sid'], 'old-token')
+        self.assertEqual(session.request.call_args_list[1].kwargs['cookies']['connect.sid'], 'new-token')
+
+    async def test_permission_403_does_not_retry_login(self):
+        resp = _mock_response(403, {'message': 'You do not have permission to access this endpoint'})
+        session = _mock_session(resp)
+        with patch.object(self.client, '_get_session', AsyncMock(return_value=session)), \
+             patch.object(self.client, 'login', AsyncMock()) as mock_login, \
+             patch('asyncio.sleep', AsyncMock()):
+            result = await self.client._make_request('POST', 'api/v1/request', retries=3)
+
+        self.assertIsNone(result)
+        mock_login.assert_not_awaited()
+        self.assertEqual(session.request.call_count, 1)
+
     async def test_returns_none_on_client_error(self):
         session = MagicMock()
         session.request = MagicMock(side_effect=aiohttp.ClientError('refused'))
@@ -558,7 +591,7 @@ class TestSubmitQueuedRequest(unittest.IsolatedAsyncioTestCase):
         return base
 
     async def test_strips_private_keys_and_returns_true_on_success(self):
-        client = _make_client()
+        client = _make_client(session_token='tok')
         payload = self._valid_payload()
         with patch.object(client, '_make_request', AsyncMock(return_value={'id': 55})) as mock_req:
             result = await client.submit_queued_request(payload)
@@ -568,15 +601,30 @@ class TestSubmitQueuedRequest(unittest.IsolatedAsyncioTestCase):
         for key in sent_data:
             self.assertFalse(key.startswith('_'), f"Private key {key!r} was not stripped")
 
+    async def test_logs_in_before_submit_when_no_session_token(self):
+        client = _make_client(session_token=None)
+        payload = self._valid_payload()
+
+        async def login():
+            client.session_token = 'fresh-token'
+
+        with patch.object(client, 'login', AsyncMock(side_effect=login)) as mock_login, \
+             patch.object(client, '_make_request', AsyncMock(return_value={'id': 55})) as mock_req:
+            result = await client.submit_queued_request(payload)
+
+        self.assertTrue(result)
+        mock_login.assert_awaited_once()
+        self.assertTrue(mock_req.call_args.kwargs['use_cookie'])
+
     async def test_returns_false_on_failure_response(self):
-        client = _make_client()
+        client = _make_client(session_token='tok')
         with patch.object(client, '_make_request', AsyncMock(return_value=None)), \
              patch.object(client, '_fetch_server_defaults', AsyncMock(return_value={'profileId': 1, 'rootFolder': '/movies'})):
             result = await client.submit_queued_request({'mediaType': 'movie', 'mediaId': 1})
         self.assertFalse(result)
 
     async def test_fetches_defaults_and_succeeds_when_profile_id_missing(self):
-        client = _make_client()
+        client = _make_client(session_token='tok')
         payload = {'mediaType': 'movie', 'mediaId': 200, 'serverId': 0}
         defaults = {'profileId': 3, 'rootFolder': '/movies'}
         with patch.object(client, '_fetch_server_defaults', AsyncMock(return_value=defaults)), \
@@ -601,14 +649,14 @@ class TestSubmitQueuedRequest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result)
 
     async def test_returns_false_on_error_response(self):
-        client = _make_client()
+        client = _make_client(session_token='tok')
         with patch.object(client, '_make_request', AsyncMock(return_value={'error': 'Bad Request'})):
             result = await client.submit_queued_request(self._valid_payload())
         self.assertFalse(result)
 
     async def test_no_fallback_fetch_when_profile_already_present(self):
         """_fetch_server_defaults must not be called when profileId and rootFolder are set."""
-        client = _make_client()
+        client = _make_client(session_token='tok')
         with patch.object(client, '_fetch_server_defaults', AsyncMock()) as mock_fallback, \
              patch.object(client, '_make_request', AsyncMock(return_value={'id': 1})):
             await client.submit_queued_request(self._valid_payload())

--- a/api_service/utils/asyncio_loop.py
+++ b/api_service/utils/asyncio_loop.py
@@ -32,6 +32,12 @@ async def _drain_pending_tasks(logger=None, timeout: float = 5.0) -> None:
         await asyncio.gather(*pending, return_exceptions=True)
 
 
+async def _flush_ready_callbacks() -> None:
+    """Run callbacks scheduled by async cleanup before loop shutdown."""
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
 def close_event_loop(loop: asyncio.AbstractEventLoop, logger=None) -> None:
     """Drain pending cleanup tasks, then close a manually-created event loop."""
     if loop.is_closed():
@@ -39,10 +45,13 @@ def close_event_loop(loop: asyncio.AbstractEventLoop, logger=None) -> None:
 
     try:
         loop.run_until_complete(_drain_pending_tasks(logger))
+        loop.run_until_complete(_flush_ready_callbacks())
         loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.run_until_complete(_flush_ready_callbacks())
         shutdown_executor = getattr(loop, "shutdown_default_executor", None)
         if shutdown_executor:
             loop.run_until_complete(shutdown_executor())
+        loop.run_until_complete(_flush_ready_callbacks())
     finally:
         loop.close()
         asyncio.set_event_loop(None)


### PR DESCRIPTION
- Fix wrong Jellyfin API endpoint used in `get_series_provider_ids` (#325)
- Improve SeerClient request handling and error management
