### PR TITLE
🧹 Remove unused import traceback in automation routes

### DIFF
--- a/api_service/blueprints/automation/routes.py
+++ b/api_service/blueprints/automation/routes.py
@@ -1,6 +1,5 @@
 import asyncio
 import threading
-import traceback
 from flask import Blueprint, jsonify, request
 from api_service.auth.limiter import limiter
 from api_service.auth.middleware import require_role


### PR DESCRIPTION
🎯 **What:** Removed the unused `traceback` import from `api_service/blueprints/automation/routes.py`.
💡 **Why:** Removing unused imports improves code maintainability and readability by reducing technical debt and noise.
✅ **Verification:** Verified syntax correctness using `py_compile`.
✨ **Result:** A cleaner and more maintainable routes file.

---
*PR created automatically by Jules for task [5873189310838874741](https://jules.google.com/task/5873189310838874741) started by @giuseppe99barchetta*