### PR TITLE
Batch IMDB API lookups in TMDb discover

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-05 - [Batched asyncio Requests for IMDB filtering]
+**Learning:** During Discover API filtering, calling OMDB sequentially inside a `for` loop over the page result items introduces an N+1 latency bottleneck.
+**Action:** Used an inner `async def` processor alongside `asyncio.gather` in a chunked batch (e.g. 5 items) to fetch IMDB ids in parallel while satisfying max_results quotas effectively.

--- a/api_service/services/tmdb/tmdb_discover.py
+++ b/api_service/services/tmdb/tmdb_discover.py
@@ -123,6 +123,22 @@ class TMDbDiscover:
                 media_type, rating_source, imdb_rating_gte, imdb_min_votes
             )
 
+        async def process_item(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+            if use_imdb:
+                imdb_id = await self._get_imdb_id(item['id'], media_type)
+                if imdb_id:
+                    imdb_data = await self.omdb_client.get_rating(imdb_id)
+                    if not self._check_imdb_filter(
+                        imdb_data, item, imdb_rating_gte, imdb_min_votes, include_no_rating
+                    ):
+                        return None
+                elif not include_no_rating:
+                    title = item.get('title') or item.get('name', 'Unknown')
+                    self.logger.debug("Excluding %s: no IMDB ID found in TMDB data", title)
+                    return None
+
+            return self._format_result(item, media_type)
+
         for page in range(1, pages_needed + 1):
             self.logger.debug(f"Fetching discover page {page} for {media_type}")
 
@@ -131,22 +147,16 @@ class TMDbDiscover:
                 self.logger.warning(f"No data returned for page {page}")
                 break
 
-            for item in data['results']:
-                if use_imdb:
-                    imdb_id = await self._get_imdb_id(item['id'], media_type)
-                    if imdb_id:
-                        imdb_data = await self.omdb_client.get_rating(imdb_id)
-                        if not self._check_imdb_filter(
-                            imdb_data, item, imdb_rating_gte, imdb_min_votes, include_no_rating
-                        ):
-                            continue
-                    elif not include_no_rating:
-                        title = item.get('title') or item.get('name', 'Unknown')
-                        self.logger.debug("Excluding %s: no IMDB ID found in TMDB data", title)
-                        continue
+            batch_size = 5
+            for i in range(0, len(data['results']), batch_size):
+                batch = data['results'][i:i + batch_size]
+                batch_results = await asyncio.gather(*[process_item(item) for item in batch])
 
-                formatted = self._format_result(item, media_type)
-                results.append(formatted)
+                for res in batch_results:
+                    if res is not None:
+                        results.append(res)
+                        if len(results) >= max_results:
+                            break
 
                 if len(results) >= max_results:
                     break


### PR DESCRIPTION
💡 **What**: The optimization batches asynchronous OMDB API network requests during discovery and executes them concurrently using `asyncio.gather`. 

🎯 **Why**: When the discovery service applied IMDB-based filtering on TMDB results, the application called OMDB sequentially for every item in a loop. This sequential waiting created a significant N+1 performance bottleneck. By chunking requests in small concurrent batches (e.g., 5 items at a time), we drastically improve execution time while preventing API rate limits.

📊 **Impact**: Expected significant reduction in backend discovery response time, particularly when filtering large result sets. This will be proportional to the batch size without risking 429 rate limit responses. 

🔬 **Measurement**: The impact can be verified by observing timing traces or manual stopwatch execution between querying the TMDB discovery endpoint with and without `include_no_rating` flags and IMDB filtering applied.

---
*PR created automatically by Jules for task [17894305411250610426](https://jules.google.com/task/17894305411250610426) started by @giuseppe99barchetta*