### PR TITLE
fix: use max_completion_tokens in LLM connection test

### DIFF
--- a/api_service/blueprints/jobs/routes.py
+++ b/api_service/blueprints/jobs/routes.py
@@ -979,11 +979,14 @@ def test_llm_connection():
         client = OpenAI(**client_kwargs)
 
         # Make a minimal completion to verify the connection and credentials.
-        # Some OpenAI-compatible gateways reject values below 16.
+        # max_completion_tokens is used instead of the deprecated max_tokens to
+        # support current OpenAI models (o-series, gpt-4.1-*, gpt-5.x) which
+        # reject max_tokens with a 400 error. Some OpenAI-compatible gateways
+        # reject values below 16, so we keep a safe minimum of 16.
         client.chat.completions.create(
             model=model,
             messages=[{'role': 'user', 'content': 'Hi'}],
-            max_tokens=16,
+            max_completion_tokens=16,
         )
 
         return jsonify({'status': 'success', 'message': 'Connection successful!'}), 200

--- a/api_service/test/test_jobs_llm_routes.py
+++ b/api_service/test/test_jobs_llm_routes.py
@@ -55,7 +55,8 @@ class TestLlmConnectionRoute(unittest.TestCase):
             })
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(calls[0]['max_tokens'], 16)
+        self.assertEqual(calls[0]['max_completion_tokens'], 16)
+        self.assertNotIn('max_tokens', calls[0])
 
 
 class TestAsyncLoopCleanup(unittest.TestCase):


### PR DESCRIPTION
## Problem

The `/api/jobs/llm-test` endpoint fails for all current OpenAI models (gpt-4.1-*, o-series, gpt-5.x) with:

```
Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': 'unsupported_parameter'}}
```

This causes the LLM connection test to fail in the settings UI even with valid credentials, making it impossible to confirm that the configuration is correct.

## Root Cause

In `api_service/blueprints/jobs/routes.py`, `test_llm_connection()` sends a minimal probe request with `max_tokens=16`. OpenAI deprecated `max_tokens` for all reasoning and latest-generation models in favour of `max_completion_tokens`.

## Fix

Replace `max_tokens=16` → `max_completion_tokens=16` in the connection-test call. The value (16) and its purpose — ensuring the request carries a token budget large enough to satisfy strict OpenAI-compatible gateways — are unchanged.

The corresponding unit-test assertion is updated to match (`calls[0]['max_completion_tokens'] == 16`) and an explicit `assertNotIn('max_tokens', calls[0])` guard is added.

## Files changed

- `api_service/blueprints/jobs/routes.py` — one-line change in `test_llm_connection()`
- `api_service/test/test_jobs_llm_routes.py` — updated assertion + added negative assertion