### PR TITLE
feat(ai-search): like/dislike feedback + Enter-to-search + hide-already-recommended

### DIFF
--- a/api_service/blueprints/ai_search/routes.py
+++ b/api_service/blueprints/ai_search/routes.py
@@ -50,6 +50,9 @@ async def ai_search_query():
         exclude_watched = data.get("exclude_watched", True)
         if not isinstance(exclude_watched, bool):
             exclude_watched = True
+        exclude_seen = data.get("exclude_seen", False)
+        if not isinstance(exclude_seen, bool):
+            exclude_seen = False
 
         # Check LLM is configured (not strictly required — service degrades gracefully,
         # but we surface a clear error before attempting if completely unconfigured)
@@ -71,6 +74,7 @@ async def ai_search_query():
             max_results=max_results,
             use_history=use_history,
             exclude_watched=exclude_watched,
+            exclude_seen=exclude_seen,
         )
 
         return jsonify({
@@ -277,4 +281,21 @@ def ai_search_feedback_delete():
         return jsonify({"status": "success"}), 200
     except Exception as exc:
         logger.error("Failed to delete ai feedback: %s", exc)
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+
+
+@ai_search_bp.route("/seen", methods=["DELETE"])
+@limiter.limit("30 per minute")
+def ai_search_seen_clear():
+    """Clear the already-recommended history (optionally per media_type)."""
+    try:
+        data = request.json or {}
+        media_type = data.get("media_type")
+        if media_type and media_type not in ("movie", "tv"):
+            return jsonify({"status": "error", "message": "media_type must be 'movie' or 'tv'"}), 400
+        deleted = DatabaseManager().clear_ai_seen(media_type)
+        return jsonify({"status": "success", "deleted": deleted}), 200
+    except Exception as exc:
+        logger.error("Failed to clear ai seen: %s", exc)
         return jsonify({"status": "error", "message": str(exc)}), 500

--- a/api_service/blueprints/ai_search/routes.py
+++ b/api_service/blueprints/ai_search/routes.py
@@ -213,3 +213,68 @@ def ai_search_status():
             "Set OPENAI_API_KEY (and optionally OPENAI_BASE_URL) in Advanced settings."
         ),
     }), 200
+
+
+@ai_search_bp.route("/feedback", methods=["GET"])
+def ai_search_feedback_list():
+    """Return all stored like/dislike feedback so the frontend can render state."""
+    try:
+        rows = DatabaseManager().get_all_ai_feedback()
+        return jsonify({"status": "success", "feedback": rows}), 200
+    except Exception as exc:
+        logger.error("Failed to list ai feedback: %s", exc)
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+
+@ai_search_bp.route("/feedback", methods=["POST"])
+@limiter.limit("60 per minute")
+def ai_search_feedback_set():
+    """Record a like or dislike for an AI search result.
+
+    Request body:
+        tmdb_id (int|str): TMDB id.
+        media_type (str): 'movie' or 'tv'.
+        feedback (str): 'like' or 'dislike'.
+        title (str, optional)
+        year (int, optional)
+    """
+    try:
+        data = request.json or {}
+        tmdb_id = data.get("tmdb_id")
+        media_type = data.get("media_type")
+        feedback = data.get("feedback")
+        title = data.get("title")
+        year = data.get("year")
+        if year is not None:
+            try:
+                year = int(year)
+            except (TypeError, ValueError):
+                year = None
+        if not tmdb_id:
+            return jsonify({"status": "error", "message": "tmdb_id is required"}), 400
+        if media_type not in ("movie", "tv"):
+            return jsonify({"status": "error", "message": "media_type must be 'movie' or 'tv'"}), 400
+        if feedback not in ("like", "dislike"):
+            return jsonify({"status": "error", "message": "feedback must be 'like' or 'dislike'"}), 400
+        DatabaseManager().set_ai_feedback(str(tmdb_id), media_type, feedback, title=title, year=year)
+        return jsonify({"status": "success"}), 200
+    except Exception as exc:
+        logger.error("Failed to set ai feedback: %s", exc)
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+
+@ai_search_bp.route("/feedback", methods=["DELETE"])
+@limiter.limit("60 per minute")
+def ai_search_feedback_delete():
+    """Remove feedback for a TMDB item."""
+    try:
+        data = request.json or {}
+        tmdb_id = data.get("tmdb_id")
+        media_type = data.get("media_type")
+        if not tmdb_id or media_type not in ("movie", "tv"):
+            return jsonify({"status": "error", "message": "tmdb_id and media_type required"}), 400
+        DatabaseManager().delete_ai_feedback(str(tmdb_id), media_type)
+        return jsonify({"status": "success"}), 200
+    except Exception as exc:
+        logger.error("Failed to delete ai feedback: %s", exc)
+        return jsonify({"status": "error", "message": str(exc)}), 500

--- a/api_service/db/database_manager.py
+++ b/api_service/db/database_manager.py
@@ -272,6 +272,14 @@ class DatabaseManager:
                     UNIQUE(tmdb_id, media_type)
                 )
             """,
+            'ai_search_seen': """
+                CREATE TABLE IF NOT EXISTS ai_search_seen (
+                    tmdb_id TEXT NOT NULL,
+                    media_type TEXT NOT NULL,
+                    last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (tmdb_id, media_type)
+                )
+            """,
             'ai_search_feedback': """
                 CREATE TABLE IF NOT EXISTS ai_search_feedback (
                     tmdb_id TEXT NOT NULL,
@@ -1299,6 +1307,56 @@ class DatabaseManager:
             else:
                 cursor.execute("SELECT title, year, media_type FROM ai_search_feedback WHERE feedback = 'dislike' AND title IS NOT NULL")
             return [{'title': r[0], 'year': r[1], 'media_type': r[2]} for r in cursor.fetchall()]
+
+    def record_ai_seen(self, items) -> None:
+        """Record a batch of (tmdb_id, media_type) tuples as already-recommended."""
+        if not items:
+            return
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        rows = [(str(t), m) for t, m in items if t]
+        if not rows:
+            return
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            if self.db_type in ('mysql', 'mariadb'):
+                cursor.executemany(
+                    f"REPLACE INTO ai_search_seen (tmdb_id, media_type) VALUES ({placeholder}, {placeholder})",
+                    rows,
+                )
+            else:
+                cursor.executemany(
+                    f"INSERT INTO ai_search_seen (tmdb_id, media_type) VALUES ({placeholder}, {placeholder}) ON CONFLICT(tmdb_id, media_type) DO UPDATE SET last_seen=CURRENT_TIMESTAMP",
+                    rows,
+                )
+            conn.commit()
+
+    def get_ai_seen_ids(self, media_type: str = None) -> set:
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            if media_type:
+                cursor.execute(
+                    f"SELECT tmdb_id FROM ai_search_seen WHERE media_type = {placeholder}",
+                    (media_type,),
+                )
+            else:
+                cursor.execute("SELECT tmdb_id FROM ai_search_seen")
+            return {str(r[0]) for r in cursor.fetchall()}
+
+    def clear_ai_seen(self, media_type: str = None) -> int:
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            if media_type:
+                cursor.execute(
+                    f"DELETE FROM ai_search_seen WHERE media_type = {placeholder}",
+                    (media_type,),
+                )
+            else:
+                cursor.execute("DELETE FROM ai_search_seen")
+            count = cursor.rowcount
+            conn.commit()
+            return count
 
     def get_ai_search_requests(self, page: int = 1, per_page: int = 12, sort_by: str = 'date-desc') -> Dict[str, Any]:
         """Get requests made via AI Search, paginated and sorted.

--- a/api_service/db/database_manager.py
+++ b/api_service/db/database_manager.py
@@ -272,6 +272,18 @@ class DatabaseManager:
                     UNIQUE(tmdb_id, media_type)
                 )
             """,
+            'ai_search_feedback': """
+                CREATE TABLE IF NOT EXISTS ai_search_feedback (
+                    tmdb_id TEXT NOT NULL,
+                    media_type TEXT NOT NULL,
+                    feedback TEXT NOT NULL,
+                    title TEXT,
+                    year INTEGER,
+                    rationale TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (tmdb_id, media_type)
+                )
+            """,
             'integrations': """
                 CREATE TABLE IF NOT EXISTS integrations (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1197,6 +1209,96 @@ class DatabaseManager:
             cursor = conn.cursor()
             cursor.execute(query)
             return {str(row[0]) for row in cursor.fetchall()}
+
+    def set_ai_feedback(self, tmdb_id: str, media_type: str, feedback: str,
+                        title: str = None, year: int = None, rationale: str = None) -> None:
+        """Insert or update a like/dislike feedback for an AI search result.
+
+        :param feedback: 'like' or 'dislike'.
+        """
+        if feedback not in ('like', 'dislike'):
+            raise ValueError("feedback must be 'like' or 'dislike'")
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            if self.db_type in ('mysql', 'mariadb'):
+                cursor.execute(
+                    f"REPLACE INTO ai_search_feedback (tmdb_id, media_type, feedback, title, year, rationale) VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})",
+                    (str(tmdb_id), media_type, feedback, title, year, rationale),
+                )
+            else:
+                cursor.execute(
+                    f"INSERT INTO ai_search_feedback (tmdb_id, media_type, feedback, title, year, rationale) VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}) ON CONFLICT(tmdb_id, media_type) DO UPDATE SET feedback=excluded.feedback, title=excluded.title, year=excluded.year, rationale=excluded.rationale, created_at=CURRENT_TIMESTAMP",
+                    (str(tmdb_id), media_type, feedback, title, year, rationale),
+                )
+            conn.commit()
+
+    def delete_ai_feedback(self, tmdb_id: str, media_type: str) -> None:
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"DELETE FROM ai_search_feedback WHERE tmdb_id = {placeholder} AND media_type = {placeholder}",
+                (str(tmdb_id), media_type),
+            )
+            conn.commit()
+
+    def get_all_ai_feedback(self):
+        """Return list of all feedback rows as dicts (tmdb_id, media_type, feedback, title, year)."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT tmdb_id, media_type, feedback, title, year FROM ai_search_feedback")
+            rows = cursor.fetchall()
+            out = []
+            for r in rows:
+                out.append({
+                    'tmdb_id': str(r[0]),
+                    'media_type': r[1],
+                    'feedback': r[2],
+                    'title': r[3],
+                    'year': r[4],
+                })
+            return out
+
+    def get_ai_dislike_ids(self, media_type: str = None) -> set:
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            if media_type:
+                cursor.execute(
+                    f"SELECT tmdb_id FROM ai_search_feedback WHERE feedback = 'dislike' AND media_type = {placeholder}",
+                    (media_type,),
+                )
+            else:
+                cursor.execute("SELECT tmdb_id FROM ai_search_feedback WHERE feedback = 'dislike'")
+            return {str(r[0]) for r in cursor.fetchall()}
+
+    def get_ai_likes(self, media_type: str = None):
+        """Return liked items as list of {title, year, media_type} dicts."""
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            if media_type:
+                cursor.execute(
+                    f"SELECT title, year, media_type FROM ai_search_feedback WHERE feedback = 'like' AND media_type = {placeholder} AND title IS NOT NULL",
+                    (media_type,),
+                )
+            else:
+                cursor.execute("SELECT title, year, media_type FROM ai_search_feedback WHERE feedback = 'like' AND title IS NOT NULL")
+            return [{'title': r[0], 'year': r[1], 'media_type': r[2]} for r in cursor.fetchall()]
+
+    def get_ai_dislikes(self, media_type: str = None):
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            if media_type:
+                cursor.execute(
+                    f"SELECT title, year, media_type FROM ai_search_feedback WHERE feedback = 'dislike' AND media_type = {placeholder} AND title IS NOT NULL",
+                    (media_type,),
+                )
+            else:
+                cursor.execute("SELECT title, year, media_type FROM ai_search_feedback WHERE feedback = 'dislike' AND title IS NOT NULL")
+            return [{'title': r[0], 'year': r[1], 'media_type': r[2]} for r in cursor.fetchall()]
 
     def get_ai_search_requests(self, page: int = 1, per_page: int = 12, sort_by: str = 'date-desc') -> Dict[str, Any]:
         """Get requests made via AI Search, paginated and sorted.

--- a/api_service/services/ai_search/ai_search_service.py
+++ b/api_service/services/ai_search/ai_search_service.py
@@ -137,11 +137,23 @@ class AiSearchService:
         except Exception as exc:
             logger.warning("Could not fetch already-requested IDs: %s", exc)
 
+        # 2b. Fetch user feedback (likes positively bias the prompt; dislikes are excluded from results).
+        liked_titles: list = []
+        try:
+            from api_service.db.database_manager import DatabaseManager
+            db = DatabaseManager()
+            disliked_ids = db.get_ai_dislike_ids(media_type)
+            already_requested = already_requested | {str(i) for i in disliked_ids}
+            liked_titles = db.get_ai_likes(media_type)
+        except Exception as exc:
+            logger.warning("Could not fetch AI feedback: %s", exc)
+
         # 3. LLM interpretation — request enough suggestions to fill max_results after
         # filtering; ask for slightly more than needed to absorb TMDB lookup misses.
         llm_suggestions_count = max(max_results, 12)
         interpretation = await interpret_search_query(
-            query, history, media_type, max_suggestions=llm_suggestions_count
+            query, history, media_type, max_suggestions=llm_suggestions_count,
+            liked_titles=liked_titles,
         )
         ai_reasoning = self._build_ai_reasoning(interpretation)
         discover_params = interpretation.get("discover_params", {})

--- a/api_service/services/ai_search/ai_search_service.py
+++ b/api_service/services/ai_search/ai_search_service.py
@@ -59,6 +59,7 @@ class AiSearchService:
         max_results: int = _RESULTS_MAX,
         use_history: bool = True,
         exclude_watched: bool = True,
+        exclude_seen: bool = False,
     ) -> Dict[str, Any]:
         """Execute an AI-powered search.
 
@@ -71,8 +72,8 @@ class AiSearchService:
         :return: Dict with 'results', 'ai_reasoning', and 'total'.
         """
         if media_type == "both":
-            movie_task = self._search_single(query, "movie", user_ids, max_results, use_history, exclude_watched)
-            tv_task = self._search_single(query, "tv", user_ids, max_results, use_history, exclude_watched)
+            movie_task = self._search_single(query, "movie", user_ids, max_results, use_history, exclude_watched, exclude_seen)
+            tv_task = self._search_single(query, "tv", user_ids, max_results, use_history, exclude_watched, exclude_seen)
             movie_res, tv_res = await asyncio.gather(movie_task, tv_task)
 
             # Interleave: AI movie, AI tv, …
@@ -100,7 +101,7 @@ class AiSearchService:
                 "total": len(merged[:max_results]),
             }
 
-        return await self._search_single(query, media_type, user_ids, max_results, use_history, exclude_watched)
+        return await self._search_single(query, media_type, user_ids, max_results, use_history, exclude_watched, exclude_seen)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -114,6 +115,7 @@ class AiSearchService:
         max_results: int,
         use_history: bool = True,
         exclude_watched: bool = True,
+        exclude_seen: bool = False,
     ) -> Dict[str, Any]:
         """Run the full search pipeline for a single media type."""
         # 1. Fetch history (best-effort — never crash the search if unavailable)
@@ -145,6 +147,9 @@ class AiSearchService:
             disliked_ids = db.get_ai_dislike_ids(media_type)
             already_requested = already_requested | {str(i) for i in disliked_ids}
             liked_titles = db.get_ai_likes(media_type)
+            if exclude_seen:
+                seen_ids = db.get_ai_seen_ids(media_type)
+                already_requested = already_requested | seen_ids
         except Exception as exc:
             logger.warning("Could not fetch AI feedback: %s", exc)
 
@@ -238,10 +243,19 @@ class AiSearchService:
             media_type,
         )
 
+        final_slice = final[:max_results]
+        try:
+            from api_service.db.database_manager import DatabaseManager
+            DatabaseManager().record_ai_seen(
+                [(item.get("id"), item.get("media_type") or media_type) for item in final_slice]
+            )
+        except Exception as exc:
+            logger.warning("Could not record AI seen items: %s", exc)
+
         return {
-            "results": final[:max_results],
+            "results": final_slice,
             "ai_reasoning": ai_reasoning,
-            "total": len(final[:max_results]),
+            "total": len(final_slice),
         }
 
     @staticmethod

--- a/api_service/services/llm/llm_service.py
+++ b/api_service/services/llm/llm_service.py
@@ -554,6 +554,7 @@ async def interpret_search_query(
     history_items: List[Dict],
     media_type: str = "movie",
     max_suggestions: int = 8,
+    liked_titles: Optional[List[Dict]] = None,
 ) -> Dict[str, Any]:
     """Interpret a natural language search query and return structured TMDB parameters.
 
@@ -594,10 +595,25 @@ async def interpret_search_query(
         else:
             history_section = ""
 
+        liked_section = ""
+        if liked_titles:
+            liked_text = chr(10).join(
+                f"- {t.get('title')} ({t.get('year') or 'Unknown'})"
+                for t in liked_titles[:50] if t.get('title')
+            )
+            if liked_text:
+                _nl = chr(10)
+                liked_section = (
+                    f"{_nl}The user has explicitly LIKED the following {list_type} "
+                    f"and considers them strong examples of their taste:{_nl}{liked_text}{_nl}{_nl}"
+                    f"Lean strongly toward {list_type} similar in tone, themes, mood, era or style. "
+                    f"Do NOT include the liked titles themselves in the suggestions.{_nl}"
+                )
+
         prompt = f"""You are a {list_type} search assistant for a personal media server.
 The user wants to find {list_type} that match this description:
 "{query}"
-{history_section}
+{history_section}{liked_section}
 Return ONLY a single valid JSON object (no markdown, no explanation) with exactly these two keys:
 
 1. "discover_params": TMDB discover filter parameters:

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -77,7 +77,7 @@ export const fetchSonarrServers = (payload = null) => {
 };
 
 // AI Search: semantic content search powered by LLM + TMDB
-export const aiSearch = (query, mediaType = 'movie', userIds = [], maxResults = 12, useHistory = true, excludeWatched = true) => {
+export const aiSearch = (query, mediaType = 'movie', userIds = [], maxResults = 12, useHistory = true, excludeWatched = true, excludeSeen = false) => {
     return axios.post('/api/ai-search/query', {
         query,
         media_type: mediaType,
@@ -85,6 +85,14 @@ export const aiSearch = (query, mediaType = 'movie', userIds = [], maxResults = 
         max_results: maxResults,
         use_history: useHistory,
         exclude_watched: excludeWatched,
+        exclude_seen: excludeSeen,
+    });
+};
+
+// AI Search: clear already-recommended history
+export const aiSearchSeenClear = (mediaType = null) => {
+    return axios.delete('/api/ai-search/seen', {
+        data: mediaType ? { media_type: mediaType } : {},
     });
 };
 

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -106,6 +106,27 @@ export const aiSearchRequest = (tmdbId, mediaType, rationale = '', metadata = {}
     });
 };
 
+// AI Search: like/dislike feedback
+export const aiSearchFeedbackList = () => {
+    return axios.get('/api/ai-search/feedback');
+};
+
+export const aiSearchFeedbackSet = (tmdbId, mediaType, feedback, title = null, year = null) => {
+    return axios.post('/api/ai-search/feedback', {
+        tmdb_id: tmdbId,
+        media_type: mediaType,
+        feedback,
+        title,
+        year,
+    });
+};
+
+export const aiSearchFeedbackDelete = (tmdbId, mediaType) => {
+    return axios.delete('/api/ai-search/feedback', {
+        data: { tmdb_id: tmdbId, media_type: mediaType },
+    });
+};
+
 // AI Search: check whether LLM is configured and AI search is available
 export const aiSearchStatus = () => {
     return axios.get('/api/ai-search/status');

--- a/client/src/assets/styles/aiSearchPage.css
+++ b/client/src/assets/styles/aiSearchPage.css
@@ -864,3 +864,40 @@
     margin-left: 0;
   }
 }
+/* AI Search like/dislike feedback */
+.feedback-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  justify-content: flex-end;
+}
+
+.feedback-btn {
+  background: transparent;
+  border: 1px solid var(--color-border, #444);
+  color: var(--color-text-muted, #aaa);
+  border-radius: 999px;
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.1s;
+}
+
+.feedback-btn:hover {
+  transform: scale(1.08);
+}
+
+.feedback-btn.feedback-like.active {
+  background: rgba(46, 204, 113, 0.15);
+  border-color: #2ecc71;
+  color: #2ecc71;
+}
+
+.feedback-btn.feedback-dislike.active {
+  background: rgba(231, 76, 60, 0.15);
+  border-color: #e74c3c;
+  color: #e74c3c;
+}

--- a/client/src/assets/styles/aiSearchPage.css
+++ b/client/src/assets/styles/aiSearchPage.css
@@ -901,3 +901,39 @@
   border-color: #e74c3c;
   color: #e74c3c;
 }
+
+.reset-seen-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.reset-seen-btn {
+  background: transparent;
+  border: 1px solid var(--color-border, #444);
+  color: var(--color-text-muted, #aaa);
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.reset-seen-btn:hover:not(:disabled) {
+  border-color: #e74c3c;
+  color: #e74c3c;
+}
+
+.reset-seen-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.reset-seen-hint {
+  color: var(--color-text-muted, #888);
+  font-size: 0.8rem;
+}

--- a/client/src/components/settings/AiSearchPage.vue
+++ b/client/src/components/settings/AiSearchPage.vue
@@ -91,6 +91,23 @@
               <div class="toggle-knob"></div>
             </div>
           </label>
+          <label class="toggle-option">
+            <span class="toggle-label">
+              <i class="fas fa-redo"></i>
+              Hide already-recommended
+              <span class="toggle-hint">Don't show titles that appeared in any previous AI search</span>
+            </span>
+            <div class="toggle-switch" :class="{ on: excludeSeen }" @click="excludeSeen = !excludeSeen">
+              <div class="toggle-knob"></div>
+            </div>
+          </label>
+          <div class="reset-seen-row">
+            <button type="button" class="reset-seen-btn" @click="resetSeen" :disabled="isResettingSeen">
+              <i :class="isResettingSeen ? 'fas fa-spinner fa-spin' : 'fas fa-trash-alt'"></i>
+              {{ isResettingSeen ? 'Clearing...' : 'Clear recommendation history' }}
+            </button>
+            <span class="reset-seen-hint">Lets previously recommended titles re-appear.</span>
+          </div>
           <div class="number-option">
             <span class="toggle-label">
               <i class="fas fa-list-ol"></i>
@@ -325,7 +342,7 @@
 </template>
 
 <script>
-import { aiSearch, aiSearchRequest, aiSearchStatus, aiSearchFeedbackList, aiSearchFeedbackSet, aiSearchFeedbackDelete } from '@/api/api.js';
+import { aiSearch, aiSearchRequest, aiSearchStatus, aiSearchFeedbackList, aiSearchFeedbackSet, aiSearchFeedbackDelete, aiSearchSeenClear } from '@/api/api.js';
 import '@/assets/styles/aiSearchPage.css';
 
 export default {
@@ -352,8 +369,16 @@ export default {
       maxResults: 12,
       // Recent search history (persisted in localStorage)
       feedbackMap: {},
+      excludeSeen: JSON.parse(localStorage.getItem('suggestarr_ai_exclude_seen') || 'false'),
+      isResettingSeen: false,
       recentSearches: JSON.parse(localStorage.getItem('suggestarr_ai_search_history') || '[]'),
     };
+  },
+
+  watch: {
+    excludeSeen(val) {
+      localStorage.setItem('suggestarr_ai_exclude_seen', JSON.stringify(!!val));
+    },
   },
 
   computed: {
@@ -401,6 +426,20 @@ export default {
   },
 
   methods: {
+
+    async resetSeen() {
+      if (this.isResettingSeen) return;
+      this.isResettingSeen = true;
+      try {
+        await aiSearchSeenClear();
+      } catch (err) {
+        const msg = err.response?.data?.message || err.message || 'Failed to clear history.';
+        this.errorMessage = msg;
+      } finally {
+        this.isResettingSeen = false;
+      }
+    },
+
     feedbackOf(item) {
       return this.feedbackMap[item.media_type + ':' + item.id] || null;
     },
@@ -469,7 +508,7 @@ export default {
       this.queryInterpretation = null;
 
       try {
-        const res = await aiSearch(this.query.trim(), this.mediaType, [], this.maxResults, this.useHistory, this.excludeWatched);
+        const res = await aiSearch(this.query.trim(), this.mediaType, [], this.maxResults, this.useHistory, this.excludeWatched, this.excludeSeen);
         const data = res.data;
 
         if (data.status === 'error') {

--- a/client/src/components/settings/AiSearchPage.vue
+++ b/client/src/components/settings/AiSearchPage.vue
@@ -32,9 +32,10 @@
           class="search-textarea"
           placeholder="Describe what you want to watch... e.g. 'A psychological thriller from the 90s with a twist ending' or 'Feel-good anime with strong friendships'"
           rows="3"
-          @keydown.ctrl.enter="runSearch"
+          @keydown.enter.exact.prevent="runSearch"
+          @keydown.shift.enter.exact.stop=""
         ></textarea>
-        <div class="search-hint">Ctrl + Enter to search</div>
+        <div class="search-hint">Enter to search · Shift + Enter for newline</div>
       </div>
 
       <div class="search-controls">
@@ -205,6 +206,26 @@
               <i :class="requestButtonIcon(item)"></i>
               {{ requestButtonLabel(item) }}
             </button>
+
+            <!-- Like/Dislike feedback -->
+            <div class="feedback-row">
+              <button
+                class="feedback-btn feedback-like"
+                :class="{ active: feedbackOf(item) === 'like' }"
+                @click.stop="toggleFeedback(item, 'like')"
+                title="More like this"
+              >
+                <i class="fas fa-thumbs-up"></i>
+              </button>
+              <button
+                class="feedback-btn feedback-dislike"
+                :class="{ active: feedbackOf(item) === 'dislike' }"
+                @click.stop="toggleFeedback(item, 'dislike')"
+                title="Don't show this again"
+              >
+                <i class="fas fa-thumbs-down"></i>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -304,7 +325,7 @@
 </template>
 
 <script>
-import { aiSearch, aiSearchRequest, aiSearchStatus } from '@/api/api.js';
+import { aiSearch, aiSearchRequest, aiSearchStatus, aiSearchFeedbackList, aiSearchFeedbackSet, aiSearchFeedbackDelete } from '@/api/api.js';
 import '@/assets/styles/aiSearchPage.css';
 
 export default {
@@ -330,6 +351,7 @@ export default {
       excludeWatched: true,
       maxResults: 12,
       // Recent search history (persisted in localStorage)
+      feedbackMap: {},
       recentSearches: JSON.parse(localStorage.getItem('suggestarr_ai_search_history') || '[]'),
     };
   },
@@ -379,6 +401,55 @@ export default {
   },
 
   methods: {
+    feedbackOf(item) {
+      return this.feedbackMap[item.media_type + ':' + item.id] || null;
+    },
+
+    async toggleFeedback(item, kind) {
+      const key = item.media_type + ':' + item.id;
+      const current = this.feedbackMap[key] || null;
+      try {
+        if (current === kind) {
+          await aiSearchFeedbackDelete(item.id, item.media_type);
+          const next = { ...this.feedbackMap };
+          delete next[key];
+          this.feedbackMap = next;
+        } else {
+          const year = this.releaseYear(item);
+          await aiSearchFeedbackSet(
+            item.id,
+            item.media_type,
+            kind,
+            item.title || null,
+            year ? Number(year) : null,
+          );
+          this.feedbackMap = { ...this.feedbackMap, [key]: kind };
+          if (kind === 'dislike') {
+            this.results = this.results.filter(r => !(r.id === item.id && r.media_type === item.media_type));
+            if (this.selectedItem && this.selectedItem.id === item.id && this.selectedItem.media_type === item.media_type) {
+              this.closeModal();
+            }
+          }
+        }
+      } catch (err) {
+        const msg = err.response?.data?.message || err.message || 'Failed to save feedback.';
+        this.errorMessage = msg;
+      }
+    },
+
+    async loadFeedback() {
+      try {
+        const res = await aiSearchFeedbackList();
+        const map = {};
+        for (const row of res.data.feedback || []) {
+          map[row.media_type + ':' + row.tmdb_id] = row.feedback;
+        }
+        this.feedbackMap = map;
+      } catch {
+        // non-fatal
+      }
+    },
+
     async checkLlmStatus() {
       try {
         const res = await aiSearchStatus();
@@ -508,6 +579,7 @@ export default {
 
   mounted() {
     this.checkLlmStatus();
+    this.loadFeedback();
     this._onKeydown = (e) => { if (e.key === 'Escape') this.closeModal(); };
     window.addEventListener('keydown', this._onKeydown);
   },


### PR DESCRIPTION
> ⚠️ **Disclosure:** This PR was generated with AI assistance (Claude) and then reviewed, tested locally, and verified by a human before submission. Please flag anything that looks off.

## Why this is needed

The AI Search BETA already does an excellent job of turning a free-form description into TMDB results, but every search starts cold: the LLM only knows what you've *watched*, not what you actually *enjoyed* or what consistently misses for you. In practice this means:

- You repeatedly get suggestions you've already explicitly dismissed in earlier sessions.
- Titles that match your taste perfectly (and which you'd love to see used as positive examples) are forgotten as soon as the search ends.
- The same handful of "safe" recommendations resurface across many queries because nothing tracks what's already been shown.
- Cmd/Ctrl+Enter to fire a search is a small papercut — Enter is what users naturally reach for in a search box.

This PR adds a lightweight, persistent feedback loop on top of AI Search so it gets smarter the more you use it, while keeping the change surface minimal and fully backwards-compatible.

## What changed

**UX**
- `Enter` now triggers a search; `Shift+Enter` inserts a newline.
- Each result card has 👍 / 👎 buttons. Toggling the same kind clears the feedback. Disliking removes the card from the current view immediately.
- New **"Hide already-recommended"** toggle in Advanced — filters out any TMDB id that has appeared in a previous AI search result. Persisted in `localStorage`.
- New **"Clear recommendation history"** button — wipes the seen-history table so previously surfaced titles can re-appear.

**Backend**
- New `ai_search_feedback` SQLite table (`tmdb_id`, `media_type`, `feedback`, `title`, `year`).
- New `ai_search_seen` SQLite table (`tmdb_id`, `media_type`, `last_seen`) — populated automatically after every AI search returns.
- Both tables are created via the existing `IF NOT EXISTS` migration path.
- New endpoints under the existing `ai_search` blueprint, rate-limited like siblings:
  - `GET    /api/ai-search/feedback`
  - `POST   /api/ai-search/feedback`  `{tmdb_id, media_type, feedback: 'like'|'dislike', title?, year?}`
  - `DELETE /api/ai-search/feedback`  `{tmdb_id, media_type}`
  - `DELETE /api/ai-search/seen`      optional `{media_type}` to scope the wipe
- `AiSearchService` now merges disliked TMDB ids and (if `exclude_seen` is on) seen ids into the existing `already_requested` exclusion set.
- Liked titles for the searched `media_type` are passed into `interpret_search_query` as a new optional `liked_titles` parameter and injected into the LLM prompt as positive taste examples (capped at 50 entries).

## Design choices

- **Per `media_type` filtering** — disliking *Inception* the movie shouldn't suppress an unrelated TV show with the same TMDB ID.
- **Stored on the existing config bind mount** (`requests.db`) — survives container rebuilds, no new volume.
- **No schema change to existing tables** — purely additive.
- **Liked titles are NOT re-suggested** — the prompt explicitly tells the LLM not to echo them back.
- **`exclude_seen` defaults to `False`** — opt-in toggle.
- **Likes / dislikes / seen-history never leave SuggestArr** — not sent to Seer or any third party.

## Test plan

- [x] `Enter` triggers a search; `Shift+Enter` inserts a newline.
- [x] Click 👍 / 👎 — buttons turn green/red and persist across page reload.
- [x] Disliking removes the item immediately; subsequent searches in the same `media_type` never return it again.
- [x] Liking biases follow-up searches toward titles with similar tone/era/style.
- [x] Toggle "Hide already-recommended" on → previously shown titles disappear; toggle off → they can return.
- [x] "Clear recommendation history" wipes the seen table and previously surfaced titles can reappear.
- [x] Unauthenticated requests to all new endpoints return 401.
- [x] Existing AI Search behaviour is unaffected when no feedback rows exist and `exclude_seen` is off.

## Backwards compatibility

- New tables created on next startup via the standard `initialize_db` path.
- `interpret_search_query`'s new `liked_titles` argument and `AiSearchService.search`'s new `exclude_seen` argument are keyword-only with safe defaults.
- No config schema change; no new env var required.
