### PR TITLE
feat(automation): cleanup unfavorited SuggestArr requests after grace period

### DIFF
--- a/api_service/app.py
+++ b/api_service/app.py
@@ -2,6 +2,7 @@
 Main Flask application for managing environment variables and running processes.
 """
 from concurrent.futures import ThreadPoolExecutor
+from html import escape
 import os
 from flask import Flask, send_from_directory, jsonify
 from flask_cors import CORS
@@ -46,11 +47,24 @@ class SubpathMiddleware:
         subpath = env_vars.get('SUBPATH')
         subpath = str(subpath).strip('/') if subpath else ''
         
-        if subpath and environ['PATH_INFO'].startswith(f'/{subpath}'):
+        if subpath and environ['PATH_INFO'] == f'/{subpath}':
+            query_string = environ.get('QUERY_STRING', '')
+            location = f'/{subpath}/'
+            if query_string:
+                location = f'{location}?{query_string}'
+
+            start_response(
+                '308 Permanent Redirect',
+                [
+                    ('Location', location),
+                    ('Content-Type', 'text/plain; charset=utf-8'),
+                    ('Content-Length', '0'),
+                ],
+            )
+            return [b'']
+
+        if subpath and environ['PATH_INFO'].startswith(f'/{subpath}/'):
             # Strip the subpath from PATH_INFO.
-            # If the URL is exactly /<subpath> (no trailing slash), the result
-            # would be an empty string which is not a valid WSGI PATH_INFO.
-            # Fall back to '/' so Flask can match the root route.
             stripped = environ['PATH_INFO'][len(subpath) + 1:]
             environ['PATH_INFO'] = stripped if stripped else '/'
             # Ensure SCRIPT_NAME correctly reflects the subpath
@@ -252,8 +266,11 @@ def register_routes(app): # pylint: disable=redefined-outer-name
                 subpath_prefix = ''
                 
             # Inject subpath so frontend knows its base URL
-            meta_tag = f'<meta name="suggestarr-subpath" content="{subpath_prefix}">'
-            content = content.replace('<head>', f'<head>{meta_tag}')
+            escaped_subpath = escape(subpath_prefix, quote=True)
+            injected_tags = f'<meta name="suggestarr-subpath" content="{escaped_subpath}">'
+            if subpath_prefix:
+                injected_tags += f'<base href="{escaped_subpath}/">'
+            content = content.replace('<head>', f'<head>{injected_tags}')
             
             return Response(content, mimetype='text/html')
         else:

--- a/api_service/app.py
+++ b/api_service/app.py
@@ -2,9 +2,8 @@
 Main Flask application for managing environment variables and running processes.
 """
 from concurrent.futures import ThreadPoolExecutor
-from html import escape
 import os
-from flask import Flask, send_from_directory, jsonify
+from flask import Flask, jsonify
 from flask_cors import CORS
 from werkzeug.middleware.proxy_fix import ProxyFix
 from asgiref.wsgi import WsgiToAsgi
@@ -13,7 +12,6 @@ import atexit
 
 from api_service.utils.utils import AppUtils
 from api_service.config.logger_manager import LoggerManager
-from api_service.config.config import load_env_vars
 
 from api_service.auth.middleware import enforce_authentication
 from api_service.auth.limiter import limiter
@@ -33,43 +31,7 @@ from api_service.blueprints.ai_search.routes import ai_search_bp
 from api_service.blueprints.health.routes import health_bp
 from api_service.blueprints.admin.routes import admin_bp
 from api_service.blueprints.users.routes import users_bp
-
-class SubpathMiddleware:
-    """
-    WSGI Middleware to strip the SUBPATH from the request URL
-    so Flask routing works correctly behind various reverse proxies.
-    """
-    def __init__(self, app):
-        self.app = app
-
-    def __call__(self, environ, start_response):
-        env_vars = load_env_vars()
-        subpath = env_vars.get('SUBPATH')
-        subpath = str(subpath).strip('/') if subpath else ''
-        
-        if subpath and environ['PATH_INFO'] == f'/{subpath}':
-            query_string = environ.get('QUERY_STRING', '')
-            location = f'/{subpath}/'
-            if query_string:
-                location = f'{location}?{query_string}'
-
-            start_response(
-                '308 Permanent Redirect',
-                [
-                    ('Location', location),
-                    ('Content-Type', 'text/plain; charset=utf-8'),
-                    ('Content-Length', '0'),
-                ],
-            )
-            return [b'']
-
-        if subpath and environ['PATH_INFO'].startswith(f'/{subpath}/'):
-            # Strip the subpath from PATH_INFO.
-            stripped = environ['PATH_INFO'][len(subpath) + 1:]
-            environ['PATH_INFO'] = stripped if stripped else '/'
-            # Ensure SCRIPT_NAME correctly reflects the subpath
-            environ['SCRIPT_NAME'] = f'/{subpath}'
-        return self.app(environ, start_response)
+from api_service.frontend_routes import SubpathMiddleware, register_routes
 
 executor = ThreadPoolExecutor(max_workers=3)
 logger = LoggerManager.get_logger("APP") 
@@ -89,7 +51,8 @@ def create_app():
     if AppUtils.is_last_worker():
         AppUtils.print_welcome_message() # Print only for last worker
 
-    application = Flask(__name__, static_folder='../static')
+    static_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
+    application = Flask(__name__, static_folder=static_dir)
 
     # ------------------------------------------------------------------
     # Reverse-proxy trust
@@ -205,78 +168,6 @@ def create_app():
     AppUtils.load_environment()
 
     return application
-
-def register_routes(app): # pylint: disable=redefined-outer-name
-    """
-    Register the application routes.
-    """
-
-    @app.route('/', defaults={'path': ''})
-    @app.route('/<path:path>')
-    def serve_frontend(path):
-        """
-        Serve the built frontend's index.html or any other static file.
-        API routes should be handled by blueprints, not this catch-all.
-        """
-        # API routes that reach here were not matched by blueprints - return 404
-        if path.startswith('api/'):
-            from flask import abort
-            abort(404)
-
-        app.static_folder = '../static'
-        
-        env_vars = load_env_vars()
-        subpath = env_vars.get('SUBPATH')
-        subpath = str(subpath).strip('/') if subpath else ''
-        
-        # If the browser mistakenly requested the asset including the subpath 
-        # (e.g., due to absolute vs relative resolution confusion), we strip it
-        # so we can find the actual file in the static directory.
-        if subpath and path.startswith(f"{subpath}/"):
-            path = path[len(subpath) + 1:]
-        elif subpath and path == subpath:
-            path = ""
-            
-        target_path = path if path != "" else "index.html"
-
-        # Resolve and validate the requested path against the static folder to
-        # prevent directory traversal using user-controlled `path`.
-        static_root = os.path.realpath(app.static_folder)
-        full_path = os.path.realpath(os.path.join(static_root, target_path))
-
-        # If the resolved path is outside the static root, do not serve it.
-        if os.path.commonpath([static_root, full_path]) != static_root:
-            from flask import abort
-            abort(404)
-
-        if target_path == "index.html" or not os.path.exists(full_path):
-            from flask import Response
-            index_path = os.path.join(app.static_folder, 'index.html')
-            if not os.path.exists(index_path):
-                from flask import abort
-                abort(404)
-            
-            with open(index_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-                
-                
-            if subpath:
-                subpath_prefix = '/' + subpath
-            else:
-                subpath_prefix = ''
-                
-            # Inject subpath so frontend knows its base URL
-            escaped_subpath = escape(subpath_prefix, quote=True)
-            injected_tags = f'<meta name="suggestarr-subpath" content="{escaped_subpath}">'
-            if subpath_prefix:
-                injected_tags += f'<base href="{escaped_subpath}/">'
-            content = content.replace('<head>', f'<head>{injected_tags}')
-            
-            return Response(content, mimetype='text/html')
-        else:
-            # Serve the requested file (static assets like JS, CSS, images, etc.).
-            # `target_path` has been validated to stay within `static_root`.
-            return send_from_directory(app.static_folder, target_path)
 
 app = create_app()
 app.wsgi_app = SubpathMiddleware(app.wsgi_app)

--- a/api_service/app.py
+++ b/api_service/app.py
@@ -32,6 +32,7 @@ from api_service.blueprints.ai_search.routes import ai_search_bp
 from api_service.blueprints.health.routes import health_bp
 from api_service.blueprints.admin.routes import admin_bp
 from api_service.blueprints.users.routes import users_bp
+from api_service.blueprints.cleanup.routes import cleanup_bp
 
 class SubpathMiddleware:
     """
@@ -183,6 +184,7 @@ def create_app():
     application.register_blueprint(health_bp, url_prefix='/api/health')
     application.register_blueprint(admin_bp, url_prefix='/api/admin')
     application.register_blueprint(users_bp, url_prefix='/api/users')
+    application.register_blueprint(cleanup_bp, url_prefix='/api/cleanup')
 
     # Register routes
     register_routes(application)
@@ -306,7 +308,32 @@ try:
         max_instances=1,
         replace_existing=True,
     )
-    logger.info("Jobs scheduler initialized (discover + recommendation + queue_worker)")
+
+    # Daily cleanup job (no-op when disabled in cleanup_settings)
+    from api_service.jobs.cleanup_automation import execute_cleanup_job, _run_lock as _cleanup_run_lock
+    import asyncio as _asyncio
+    def _run_cleanup_job():
+        if not _cleanup_run_lock.acquire(blocking=False):
+            logger.info("Cleanup cron skipped: a run is already in progress.")
+            return
+        try:
+            _asyncio.run(execute_cleanup_job())
+        except Exception as exc:
+            logger.error(f"Cleanup job error: {exc}")
+        finally:
+            try:
+                _cleanup_run_lock.release()
+            except RuntimeError:
+                pass
+    job_manager.scheduler.add_job(
+        _run_cleanup_job,
+        'cron',
+        hour=4, minute=15,
+        id='cleanup_automation',
+        max_instances=1,
+        replace_existing=True,
+    )
+    logger.info("Jobs scheduler initialized (discover + recommendation + queue_worker + cleanup)")
 except Exception as e:
     import traceback
     logger.error(f"Failed to initialize discover jobs scheduler: {e}")

--- a/api_service/app.py
+++ b/api_service/app.py
@@ -12,6 +12,7 @@ import atexit
 
 from api_service.utils.utils import AppUtils
 from api_service.config.logger_manager import LoggerManager
+from api_service.config.config import load_env_vars
 
 from api_service.auth.middleware import enforce_authentication
 from api_service.auth.limiter import limiter

--- a/api_service/blueprints/cleanup/routes.py
+++ b/api_service/blueprints/cleanup/routes.py
@@ -1,0 +1,91 @@
+"""Cleanup blueprint — settings + manual run + audit log for the cleanup automation."""
+
+from flask import Blueprint, jsonify, request
+
+from api_service.auth.limiter import limiter
+from api_service.config.logger_manager import LoggerManager
+from api_service.db.database_manager import DatabaseManager
+from api_service.jobs.cleanup_automation import execute_cleanup_job, _run_lock as _shared_run_lock
+
+cleanup_bp = Blueprint("cleanup", __name__)
+_run_lock = _shared_run_lock
+logger = LoggerManager.get_logger("CleanupRoute")
+
+
+@cleanup_bp.route("/settings", methods=["GET"])
+def cleanup_settings_get():
+    try:
+        return jsonify({"status": "success", "settings": DatabaseManager().get_cleanup_settings()}), 200
+    except Exception as exc:
+        logger.error("Failed to fetch cleanup settings: %s", exc)
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+
+@cleanup_bp.route("/settings", methods=["POST"])
+@limiter.limit("30 per minute")
+def cleanup_settings_set():
+    try:
+        data = request.json or {}
+        enabled = data.get("enabled")
+        dry_run = data.get("dry_run")
+        grace_days = data.get("grace_days")
+
+        if grace_days is not None:
+            try:
+                grace_days = int(grace_days)
+            except (TypeError, ValueError):
+                return jsonify({"status": "error", "message": "grace_days must be an integer"}), 400
+            if grace_days < 1 or grace_days > 365:
+                return jsonify({"status": "error", "message": "grace_days must be between 1 and 365"}), 400
+
+        for key, value in (("enabled", enabled), ("dry_run", dry_run)):
+            if value is not None and not isinstance(value, bool):
+                return jsonify({"status": "error", "message": f"{key} must be a boolean"}), 400
+
+        settings = DatabaseManager().update_cleanup_settings(
+            enabled=enabled, dry_run=dry_run, grace_days=grace_days
+        )
+        return jsonify({"status": "success", "settings": settings}), 200
+    except Exception as exc:
+        logger.error("Failed to update cleanup settings: %s", exc)
+        return jsonify({"status": "error", "message": str(exc)}), 500
+
+
+@cleanup_bp.route("/run", methods=["POST"])
+async def cleanup_run_now():
+    if not _run_lock.acquire(blocking=False):
+        return jsonify({
+            "status": "error",
+            "code": "already_running",
+            "message": "A cleanup run is already in progress. Please wait for it to finish.",
+        }), 409
+    try:
+        data = request.json or {}
+        override_dry_run = data.get("dry_run")
+        if override_dry_run is not None and not isinstance(override_dry_run, bool):
+            return jsonify({"status": "error", "message": "dry_run must be a boolean"}), 400
+        result = await execute_cleanup_job(force_run=True, override_dry_run=override_dry_run)
+        return jsonify({"status": "success", "result": result}), 200
+    except Exception as exc:
+        logger.error("Manual cleanup run failed: %s", exc)
+        return jsonify({"status": "error", "message": str(exc)}), 500
+    finally:
+        try:
+            _run_lock.release()
+        except RuntimeError:
+            pass
+
+
+@cleanup_bp.route("/log", methods=["GET"])
+def cleanup_log_list():
+    try:
+        try:
+            limit = int(request.args.get("limit", 100))
+        except (TypeError, ValueError):
+            limit = 100
+        limit = max(1, min(500, limit))
+        rows = DatabaseManager().get_cleanup_log(limit=limit)
+        return jsonify({"status": "success", "log": rows}), 200
+    except Exception as exc:
+        logger.error("Failed to fetch cleanup log: %s", exc)
+        return jsonify({"status": "error", "message": str(exc)}), 500

--- a/api_service/blueprints/jobs/routes.py
+++ b/api_service/blueprints/jobs/routes.py
@@ -979,11 +979,14 @@ def test_llm_connection():
         client = OpenAI(**client_kwargs)
 
         # Make a minimal completion to verify the connection and credentials.
-        # Some OpenAI-compatible gateways reject values below 16.
+        # max_completion_tokens is used instead of the deprecated max_tokens to
+        # support current OpenAI models (o-series, gpt-4.1-*, gpt-5.x) which
+        # reject max_tokens with a 400 error. Some OpenAI-compatible gateways
+        # reject values below 16, so we keep a safe minimum of 16.
         client.chat.completions.create(
             model=model,
             messages=[{'role': 'user', 'content': 'Hi'}],
-            max_tokens=16,
+            max_completion_tokens=16,
         )
 
         return jsonify({'status': 'success', 'message': 'Connection successful!'}), 200

--- a/api_service/db/database_manager.py
+++ b/api_service/db/database_manager.py
@@ -272,6 +272,31 @@ class DatabaseManager:
                     UNIQUE(tmdb_id, media_type)
                 )
             """,
+            'cleanup_settings': """
+                CREATE TABLE IF NOT EXISTS cleanup_settings (
+                    id INTEGER PRIMARY KEY,
+                    enabled INTEGER NOT NULL DEFAULT 0,
+                    dry_run INTEGER NOT NULL DEFAULT 1,
+                    grace_days INTEGER NOT NULL DEFAULT 7,
+                    last_run_at TIMESTAMP,
+                    last_run_status TEXT,
+                    last_run_summary TEXT,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """,
+            'cleanup_log': """
+                CREATE TABLE IF NOT EXISTS cleanup_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ran_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    tmdb_id TEXT,
+                    media_type TEXT,
+                    title TEXT,
+                    action TEXT NOT NULL,
+                    was_dry_run INTEGER NOT NULL DEFAULT 0,
+                    user_rating REAL,
+                    reason TEXT
+                )
+            """,
             'ai_search_feedback': """
                 CREATE TABLE IF NOT EXISTS ai_search_feedback (
                     tmdb_id TEXT NOT NULL,
@@ -1299,6 +1324,109 @@ class DatabaseManager:
             else:
                 cursor.execute("SELECT title, year, media_type FROM ai_search_feedback WHERE feedback = 'dislike' AND title IS NOT NULL")
             return [{'title': r[0], 'year': r[1], 'media_type': r[2]} for r in cursor.fetchall()]
+
+    def get_cleanup_settings(self) -> dict:
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT id, enabled, dry_run, grace_days, last_run_at, last_run_status, last_run_summary FROM cleanup_settings WHERE id = 1")
+            row = cursor.fetchone()
+            if not row:
+                placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+                cursor.execute(
+                    f"INSERT INTO cleanup_settings (id, enabled, dry_run, grace_days) VALUES (1, {placeholder}, {placeholder}, {placeholder})",
+                    (0, 1, 7),
+                )
+                conn.commit()
+                return {'enabled': False, 'dry_run': True, 'grace_days': 7,
+                        'last_run_at': None, 'last_run_status': None, 'last_run_summary': None}
+            return {
+                'enabled': bool(row[1]),
+                'dry_run': bool(row[2]),
+                'grace_days': int(row[3]),
+                'last_run_at': row[4],
+                'last_run_status': row[5],
+                'last_run_summary': row[6],
+            }
+
+    def update_cleanup_settings(self, enabled=None, dry_run=None, grace_days=None,
+                                last_run_at=None, last_run_status=None, last_run_summary=None) -> dict:
+        # Ensure row exists.
+        self.get_cleanup_settings()
+        sets = []
+        params = []
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        if enabled is not None:
+            sets.append(f"enabled = {placeholder}"); params.append(1 if enabled else 0)
+        if dry_run is not None:
+            sets.append(f"dry_run = {placeholder}"); params.append(1 if dry_run else 0)
+        if grace_days is not None:
+            sets.append(f"grace_days = {placeholder}"); params.append(int(grace_days))
+        if last_run_at is not None:
+            sets.append(f"last_run_at = {placeholder}"); params.append(last_run_at)
+        if last_run_status is not None:
+            sets.append(f"last_run_status = {placeholder}"); params.append(last_run_status)
+        if last_run_summary is not None:
+            sets.append(f"last_run_summary = {placeholder}"); params.append(last_run_summary)
+        sets.append("updated_at = CURRENT_TIMESTAMP")
+        if sets:
+            with self.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(f"UPDATE cleanup_settings SET {', '.join(sets)} WHERE id = 1", params)
+                conn.commit()
+        return self.get_cleanup_settings()
+
+    def add_cleanup_log(self, *, tmdb_id, media_type, title, action,
+                        was_dry_run, user_rating=None, reason=None) -> None:
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"INSERT INTO cleanup_log (tmdb_id, media_type, title, action, was_dry_run, user_rating, reason) VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})",
+                (str(tmdb_id) if tmdb_id is not None else None, media_type, title, action,
+                 1 if was_dry_run else 0, user_rating, reason),
+            )
+            conn.commit()
+
+    def get_cleanup_log(self, limit: int = 100) -> list:
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT id, ran_at, tmdb_id, media_type, title, action, was_dry_run, user_rating, reason FROM cleanup_log ORDER BY id DESC LIMIT ?".replace('?', '%s' if self.db_type in ('mysql', 'postgres') else '?'),
+                (int(limit),),
+            )
+            rows = cursor.fetchall()
+            return [{
+                'id': r[0], 'ran_at': r[1], 'tmdb_id': r[2], 'media_type': r[3],
+                'title': r[4], 'action': r[5], 'was_dry_run': bool(r[6]),
+                'user_rating': r[7], 'reason': r[8],
+            } for r in rows]
+
+    def get_suggestarr_requests_older_than(self, cutoff_iso: str) -> list:
+        """Return SuggestArr-originated requests requested before cutoff."""
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""SELECT r.tmdb_request_id, r.media_type, r.requested_at, m.title
+                     FROM requests r
+                     LEFT JOIN metadata m ON m.media_id = r.tmdb_request_id AND m.media_type = r.media_type
+                     WHERE r.requested_by = 'SuggestArr' AND r.requested_at < {placeholder}
+                     ORDER BY r.requested_at ASC""",
+                (cutoff_iso,),
+            )
+            return [{'tmdb_id': str(row[0]), 'media_type': row[1], 'requested_at': row[2], 'title': row[3]}
+                    for row in cursor.fetchall()]
+
+    def delete_request_row(self, tmdb_id: str, media_type: str) -> None:
+        placeholder = '%s' if self.db_type in ('mysql', 'postgres') else '?'
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"DELETE FROM requests WHERE tmdb_request_id = {placeholder} AND media_type = {placeholder} AND requested_by = 'SuggestArr'",
+                (str(tmdb_id), media_type),
+            )
+            conn.commit()
+
 
     def get_ai_search_requests(self, page: int = 1, per_page: int = 12, sort_by: str = 'date-desc') -> Dict[str, Any]:
         """Get requests made via AI Search, paginated and sorted.

--- a/api_service/frontend_routes.py
+++ b/api_service/frontend_routes.py
@@ -1,0 +1,132 @@
+"""
+Frontend static file and SPA fallback routing helpers.
+"""
+from html import escape
+import os
+
+from flask import Response, abort, send_from_directory
+
+from api_service.config.config import load_env_vars
+
+
+def normalize_subpath(value):
+    """Return SUBPATH as '' or '/segment' without trailing slash."""
+    if value is None:
+        return ""
+
+    normalized = str(value).strip()
+    if not normalized:
+        return ""
+
+    normalized = "/" + normalized.strip("/")
+    return "" if normalized == "/" else normalized
+
+
+def strip_subpath_prefix(path, subpath):
+    """Drop leading SUBPATH from frontend request paths when present."""
+    normalized_path = (path or "").lstrip("/")
+    if not subpath:
+        return normalized_path
+
+    subpath_prefix = subpath.lstrip("/")
+    if normalized_path == subpath_prefix:
+        return ""
+    if normalized_path.startswith(f"{subpath_prefix}/"):
+        return normalized_path[len(subpath_prefix) + 1:]
+    return normalized_path
+
+
+def request_targets_asset(path):
+    """Heuristic: asset requests usually include filename extension."""
+    normalized_path = (path or "").strip("/")
+    if not normalized_path:
+        return False
+
+    filename = normalized_path.rsplit("/", maxsplit=1)[-1]
+    return "." in filename and not filename.startswith(".")
+
+
+def _resolve_static_path(static_root, target_path):
+    full_path = os.path.realpath(os.path.join(static_root, target_path))
+    if os.path.commonpath([static_root, full_path]) != static_root:
+        abort(404)
+    return full_path
+
+
+def _render_index(static_root, subpath):
+    index_path = os.path.join(static_root, "index.html")
+    if not os.path.exists(index_path):
+        abort(404)
+
+    with open(index_path, "r", encoding="utf-8") as handle:
+        content = handle.read()
+
+    escaped_subpath = escape(subpath, quote=True)
+    injected_tags = f'<meta name="suggestarr-subpath" content="{escaped_subpath}">'
+    if subpath:
+        injected_tags += f'<base href="{escaped_subpath}/">'
+
+    return Response(content.replace("<head>", f"<head>{injected_tags}"), mimetype="text/html")
+
+
+class SubpathMiddleware:
+    """
+    WSGI middleware to strip SUBPATH from request URL so Flask routing still works.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        subpath = normalize_subpath(load_env_vars().get("SUBPATH"))
+
+        if subpath and environ["PATH_INFO"] == subpath:
+            query_string = environ.get("QUERY_STRING", "")
+            location = f"{subpath}/"
+            if query_string:
+                location = f"{location}?{query_string}"
+
+            start_response(
+                "308 Permanent Redirect",
+                [
+                    ("Location", location),
+                    ("Content-Type", "text/plain; charset=utf-8"),
+                    ("Content-Length", "0"),
+                ],
+            )
+            return [b""]
+
+        if subpath and environ["PATH_INFO"].startswith(f"{subpath}/"):
+            stripped = environ["PATH_INFO"][len(subpath):]
+            environ["PATH_INFO"] = stripped if stripped else "/"
+            environ["SCRIPT_NAME"] = subpath
+
+        return self.app(environ, start_response)
+
+
+def register_routes(app):  # pylint: disable=redefined-outer-name
+    """Register frontend routes."""
+
+    @app.route("/", defaults={"path": ""})
+    @app.route("/<path:path>")
+    def serve_frontend(path):
+        if path.startswith("api/"):
+            abort(404)
+
+        subpath = normalize_subpath(load_env_vars().get("SUBPATH"))
+        relative_path = strip_subpath_prefix(path, subpath)
+        target_path = relative_path or "index.html"
+        static_root = os.path.realpath(app.static_folder)
+
+        if target_path == "index.html":
+            return _render_index(static_root, subpath)
+
+        full_path = _resolve_static_path(static_root, target_path)
+
+        if os.path.isfile(full_path):
+            return send_from_directory(static_root, target_path)
+
+        if relative_path and request_targets_asset(relative_path):
+            abort(404)
+
+        return _render_index(static_root, subpath)

--- a/api_service/jobs/cleanup_automation.py
+++ b/api_service/jobs/cleanup_automation.py
@@ -1,0 +1,179 @@
+"""Cleanup automation: prune SuggestArr-originated requests + files when the
+underlying media has not been favorited (Plex heart / userRating == 10) within
+a configurable grace period.
+
+Safe by default: only runs when explicitly enabled, and starts in dry-run mode.
+"""
+
+import threading
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Tuple
+
+from api_service.config.logger_manager import LoggerManager
+from api_service.db.database_manager import DatabaseManager
+from api_service.services.config_service import ConfigService
+from api_service.services.plex.plex_client import PlexClient
+from api_service.services.seer.seer_client import SeerClient
+
+
+_run_lock = threading.Lock()
+FAVORITE_USER_RATING = 10.0
+SUPPORTED_MEDIA_SERVICES = {"plex"}
+
+
+async def _build_favorite_map(env_vars: Dict) -> Dict[Tuple[str, str], float]:
+    """Return mapping of (media_type, tmdb_id) -> userRating from the Plex library."""
+    plex_libraries_raw = env_vars.get('PLEX_LIBRARIES') or []
+    plex_libraries = plex_libraries_raw if isinstance(plex_libraries_raw, list) else []
+
+    plex_client = PlexClient(
+        api_url=env_vars['PLEX_API_URL'],
+        token=env_vars['PLEX_TOKEN'],
+        max_content=10000,
+        library_ids=plex_libraries,
+        user_ids=[],
+    )
+    library_items = await plex_client.get_all_library_items() or {}
+    rating_map: Dict[Tuple[str, str], float] = {}
+    for media_type, items in library_items.items():
+        for item in items or []:
+            tmdb_id = item.get('tmdb_id')
+            if not tmdb_id:
+                continue
+            try:
+                rating = float(item.get('userRating', 0) or 0)
+            except (TypeError, ValueError):
+                rating = 0.0
+            rating_map[(media_type, str(tmdb_id))] = rating
+    return rating_map
+
+
+async def execute_cleanup_job(force_run: bool = False, override_dry_run: Optional[bool] = None) -> Dict:
+    """Run the cleanup pass.
+
+    :param force_run: If True, bypass the 'enabled' gate (used by 'Run now').
+    :param override_dry_run: If set, override the configured dry_run flag for this run only.
+    :return: Summary dict.
+    """
+    logger = LoggerManager.get_logger("CleanupAutomation")
+    db = DatabaseManager()
+    settings = db.get_cleanup_settings()
+    enabled = settings.get('enabled')
+    dry_run = settings.get('dry_run') if override_dry_run is None else bool(override_dry_run)
+    grace_days = max(1, int(settings.get('grace_days') or 7))
+
+    if not enabled and not force_run:
+        logger.debug("Cleanup job disabled; skipping.")
+        return {'status': 'skipped', 'message': 'Cleanup is disabled.'}
+
+    env_vars = ConfigService.get_runtime_config()
+    media_service = (env_vars.get('SELECTED_SERVICE') or env_vars.get('MEDIA_SERVICE') or '').lower()
+    if media_service and media_service not in SUPPORTED_MEDIA_SERVICES:
+        msg = f"Cleanup currently only supports Plex (configured service: {media_service or 'unknown'})."
+        logger.warning(msg)
+        db.update_cleanup_settings(last_run_at=datetime.utcnow().isoformat(),
+                                   last_run_status='unsupported', last_run_summary=msg)
+        return {'status': 'unsupported', 'message': msg}
+
+    if not env_vars.get('PLEX_API_URL') or not env_vars.get('PLEX_TOKEN'):
+        msg = "Plex is not configured (PLEX_API_URL / PLEX_TOKEN missing)."
+        logger.warning(msg)
+        db.update_cleanup_settings(last_run_at=datetime.utcnow().isoformat(),
+                                   last_run_status='not_configured', last_run_summary=msg)
+        return {'status': 'not_configured', 'message': msg}
+
+    cutoff = (datetime.utcnow() - timedelta(days=grace_days)).isoformat()
+    candidates: List[Dict] = db.get_suggestarr_requests_older_than(cutoff)
+    logger.info("Cleanup: %d candidate request(s) older than %d day(s) (cutoff=%s, dry_run=%s).",
+                len(candidates), grace_days, cutoff, dry_run)
+
+    if not candidates:
+        summary = f"No requests older than {grace_days} days."
+        db.update_cleanup_settings(last_run_at=datetime.utcnow().isoformat(),
+                                   last_run_status='ok', last_run_summary=summary)
+        return {'status': 'ok', 'summary': summary, 'deleted': 0, 'kept': 0, 'missing': 0}
+
+    favorite_map = await _build_favorite_map(env_vars)
+
+    seer_client = None
+    if not dry_run:
+        seer_client = SeerClient(
+            env_vars['SEER_API_URL'],
+            env_vars['SEER_TOKEN'],
+            env_vars.get('SEER_USER_NAME'),
+            env_vars.get('SEER_USER_PSW'),
+            env_vars.get('SEER_SESSION_TOKEN'),
+            'all',
+            False,
+            False,
+            {},
+            False,
+        )
+
+    deleted = kept = missing = errors = 0
+    for cand in candidates:
+        tmdb_id = cand['tmdb_id']
+        media_type = cand['media_type']
+        title = cand.get('title') or f"tmdb:{tmdb_id}"
+        rating = favorite_map.get((media_type, str(tmdb_id)))
+
+        if rating is None:
+            missing += 1
+            db.add_cleanup_log(tmdb_id=tmdb_id, media_type=media_type, title=title,
+                               action='skipped_not_in_library', was_dry_run=dry_run,
+                               user_rating=None,
+                               reason='Not present in Plex library; nothing to delete here.')
+            continue
+
+        if rating >= FAVORITE_USER_RATING:
+            kept += 1
+            db.add_cleanup_log(tmdb_id=tmdb_id, media_type=media_type, title=title,
+                               action='kept_favorited', was_dry_run=dry_run,
+                               user_rating=rating, reason='Favorited (userRating >= 10).')
+            continue
+
+        if dry_run:
+            db.add_cleanup_log(tmdb_id=tmdb_id, media_type=media_type, title=title,
+                               action='would_delete', was_dry_run=True,
+                               user_rating=rating,
+                               reason=f'Not favorited after {grace_days} days; would delete files via Radarr/Sonarr.')
+            deleted += 1
+            continue
+
+        try:
+            ok = await seer_client.delete_media_file_by_tmdb(int(tmdb_id), media_type)
+            if ok:
+                deleted += 1
+                db.delete_request_row(tmdb_id, media_type)
+                db.add_cleanup_log(tmdb_id=tmdb_id, media_type=media_type, title=title,
+                                   action='deleted', was_dry_run=False,
+                                   user_rating=rating,
+                                   reason=f'Not favorited after {grace_days} days; files removed via Radarr/Sonarr.')
+            else:
+                errors += 1
+                db.add_cleanup_log(tmdb_id=tmdb_id, media_type=media_type, title=title,
+                                   action='delete_failed', was_dry_run=False,
+                                   user_rating=rating,
+                                   reason='Seer DELETE returned a non-success status; see logs.')
+        except Exception as exc:
+            errors += 1
+            logger.error("Cleanup: error deleting tmdb_id=%s media_type=%s: %s", tmdb_id, media_type, exc)
+            db.add_cleanup_log(tmdb_id=tmdb_id, media_type=media_type, title=title,
+                               action='error', was_dry_run=False, user_rating=rating,
+                               reason=str(exc)[:500])
+
+    if seer_client is not None:
+        try:
+            await seer_client.close()
+        except Exception:
+            pass
+
+    summary = (f"Candidates={len(candidates)} "
+               f"{'would_delete' if dry_run else 'deleted'}={deleted} "
+               f"kept_favorited={kept} not_in_library={missing} errors={errors}")
+    db.update_cleanup_settings(last_run_at=datetime.utcnow().isoformat(),
+                               last_run_status=('dry_run' if dry_run else 'ok'),
+                               last_run_summary=summary)
+    logger.info("Cleanup run finished: %s", summary)
+    return {'status': 'ok', 'summary': summary, 'dry_run': dry_run,
+            'deleted': deleted, 'kept': kept, 'missing': missing, 'errors': errors}

--- a/api_service/requirements.txt
+++ b/api_service/requirements.txt
@@ -21,7 +21,7 @@ requests==2.32.5
 python-dotenv==1.2.2
 PyYAML==6.0.3
 pytz==2026.1.post1
-tzdata==2025.3
+tzdata==2026.2
 
 PlexAPI==4.18.0
 simple-justwatch-python-api==0.16

--- a/api_service/requirements.txt
+++ b/api_service/requirements.txt
@@ -17,10 +17,10 @@ APScheduler==3.11.2
 croniter==6.2.2
 
 concurrent-log-handler==0.9.29
-requests==2.33.1
+requests==2.34.0
 python-dotenv==1.2.2
 PyYAML==6.0.3
-pytz==2026.1.post1
+pytz==2026.2
 tzdata==2026.2
 
 PlexAPI==4.18.1

--- a/api_service/requirements.txt
+++ b/api_service/requirements.txt
@@ -1,33 +1,33 @@
 Flask==3.1.3
 Flask-Cors==6.0.2
 Flask-Limiter==4.1.1
-PyJWT==2.11.0
+PyJWT==2.12.1
 bcrypt==5.0.0
 gunicorn==25.1.0
-uvicorn==0.41.0
+uvicorn==0.46.0
 asgiref==3.11.1
 
-aiohttp==3.13.3
-redis==7.3.0
+aiohttp==3.13.5
+redis==7.4.0
 amqp==5.3.1
 billiard==4.2.4
 kombu==5.6.2
 
 APScheduler==3.11.2
-croniter==6.0.0
+croniter==6.2.2
 
 concurrent-log-handler==0.9.29
-requests==2.32.5
+requests==2.33.1
 python-dotenv==1.2.2
 PyYAML==6.0.3
-pytz==2026.1.post1
+pytz==2026.2
 tzdata==2025.3
 
-PlexAPI==4.18.0
+PlexAPI==4.18.1
 simple-justwatch-python-api==0.16
 xmltodict==1.0.4
 
-mysql-connector-python==9.6.0
-psycopg2-binary==2.9.11
+mysql-connector-python==9.7.0
+psycopg2-binary==2.9.12
 
-openai==2.26.0
+openai==2.36.0

--- a/api_service/requirements.txt
+++ b/api_service/requirements.txt
@@ -24,7 +24,7 @@ pytz==2026.1.post1
 tzdata==2026.2
 
 PlexAPI==4.18.1
-simple-justwatch-python-api==0.16
+simple-justwatch-python-api==1.3.0
 xmltodict==1.0.4
 
 mysql-connector-python==9.7.0

--- a/api_service/requirements.txt
+++ b/api_service/requirements.txt
@@ -3,7 +3,7 @@ Flask-Cors==6.0.2
 Flask-Limiter==4.1.1
 PyJWT==2.11.0
 bcrypt==5.0.0
-gunicorn==25.1.0
+gunicorn==26.0.0
 uvicorn==0.41.0
 asgiref==3.11.1
 

--- a/api_service/services/llm/llm_service.py
+++ b/api_service/services/llm/llm_service.py
@@ -169,6 +169,47 @@ def _normalize_parsed_response(parsed: Any, schema_cls: Type[BaseModel]) -> Any:
     return parsed
 
 
+def _response_format_options(schema_cls: Type[BaseModel]) -> List[Optional[Dict[str, Any]]]:
+    """Return structured-output formats from strictest to broadest."""
+    return [
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": schema_cls.__name__,
+                "schema": schema_cls.model_json_schema(),
+                "strict": True,
+            },
+        },
+        {"type": "json_object"},
+        None,
+    ]
+
+
+def _is_response_format_rejection(exc: Exception) -> bool:
+    """Return True when provider rejects a response_format option."""
+    if getattr(exc, "status_code", None) != 400:
+        return False
+
+    details: List[str] = [str(exc)]
+    message = getattr(exc, "message", None)
+    if message:
+        details.append(str(message))
+
+    body = getattr(exc, "body", None)
+    if body is not None:
+        if isinstance(body, dict):
+            details.append(json.dumps(body, ensure_ascii=True))
+        else:
+            details.append(str(body))
+
+    detail_text = " ".join(details).lower()
+    return (
+        "response_format" in detail_text
+        or "json_object" in detail_text
+        or "json_schema" in detail_text
+    )
+
+
 # ---------------------------------------------------------------------------
 # Low-level helpers (pure / sync)
 # ---------------------------------------------------------------------------
@@ -305,11 +346,9 @@ async def _call_with_validation(
     attempt.  After *max_retries + 1* total attempts :class:`LLMValidationError`
     is raised.
 
-    ``response_format={"type": "json_object"}`` is passed to leverage native
-    JSON mode when the provider supports it (OpenAI, many Ollama models, etc.).
-    For providers that reject ``json_object`` with a 400 error (for example
-    requiring ``json_schema`` or ``text``), the same request is retried once
-    without ``response_format``.
+    Strict JSON-schema mode is tried first where supported. Providers that
+    reject a ``response_format`` with a 400 response fall back to JSON-object
+    mode, then to plain prompting without burning a validation retry.
 
     :param client: Initialised async OpenAI-compatible client.
     :param model: Model identifier string (e.g. ``"gpt-4o-mini"``).
@@ -323,46 +362,31 @@ async def _call_with_validation(
     current_messages = list(messages)
     last_error: Exception = RuntimeError("No attempts made")
 
-    def _is_response_format_json_object_rejection(exc: Exception) -> bool:
-        """Return True when *exc* is a 400 rejection for json_object response_format."""
-        if getattr(exc, "status_code", None) != 400:
-            return False
-
-        details: List[str] = [str(exc)]
-        message = getattr(exc, "message", None)
-        if message:
-            details.append(str(message))
-
-        body = getattr(exc, "body", None)
-        if body is not None:
-            if isinstance(body, dict):
-                details.append(json.dumps(body, ensure_ascii=True))
-            else:
-                details.append(str(body))
-
-        detail_text = " ".join(details).lower()
-        return "response_format" in detail_text or "json_object" in detail_text
-
     for attempt in range(max_retries + 1):
-        try:
-            response = await client.chat.completions.create(
-                model=model,
-                messages=current_messages,
-                temperature=temperature,
-                response_format={"type": "json_object"},
-            )
-        except Exception as exc:
-            if _is_response_format_json_object_rejection(exc):
-                logger.debug(
-                    "Provider rejected json_object response_format, retrying without structured output"
-                )
-                response = await client.chat.completions.create(
-                    model=model,
-                    messages=current_messages,
-                    temperature=temperature,
-                )
-            else:
+        response = None
+        for response_format in _response_format_options(schema_cls):
+            request_kwargs: Dict[str, Any] = {
+                "model": model,
+                "messages": current_messages,
+                "temperature": temperature,
+            }
+            if response_format is not None:
+                request_kwargs["response_format"] = response_format
+
+            try:
+                response = await client.chat.completions.create(**request_kwargs)
+                break
+            except Exception as exc:
+                if response_format is not None and _is_response_format_rejection(exc):
+                    logger.debug(
+                        "Provider rejected %s response_format, trying next option",
+                        response_format.get("type"),
+                    )
+                    continue
                 raise
+
+        if response is None:
+            raise RuntimeError("LLM request did not return a response")
 
         raw = response.choices[0].message.content.strip()
         content = _extract_json_object(

--- a/api_service/services/llm/llm_service.py
+++ b/api_service/services/llm/llm_service.py
@@ -147,6 +147,28 @@ def _validation_retry_message(schema_cls: Type[BaseModel]) -> str:
     return _RETRY_SYSTEM_MESSAGE
 
 
+def _normalize_parsed_response(parsed: Any, schema_cls: Type[BaseModel]) -> Any:
+    """Coerce common provider response shapes into the requested schema."""
+    if schema_cls is not RecommendationList:
+        return parsed
+
+    if isinstance(parsed, list):
+        return {"recommendations": parsed}
+
+    if not isinstance(parsed, dict) or "recommendations" in parsed:
+        return parsed
+
+    for key in ("movies", "movie_recommendations", "tv", "tv_recommendations", "results"):
+        value = parsed.get(key)
+        if isinstance(value, list):
+            normalized = dict(parsed)
+            normalized["recommendations"] = value
+            normalized.pop(key, None)
+            return normalized
+
+    return parsed
+
+
 # ---------------------------------------------------------------------------
 # Low-level helpers (pure / sync)
 # ---------------------------------------------------------------------------
@@ -176,21 +198,29 @@ def _repair_title_qualifiers(text: str) -> str:
 
 
 def _extract_json_object(text: str) -> str:
-    """Extract the first complete JSON object from text.
+    """Extract the first complete JSON object or array from text.
 
     Some providers prepend or append natural-language commentary even when
     instructed to return JSON only. This keeps only the content between the
-    first ``{`` and the last ``}``, then trims whitespace.
+    first JSON opener and its likely closing delimiter, then trims whitespace.
 
-    :param text: LLM output that should contain a JSON object.
-    :return: String narrowed to the JSON object region when delimiters exist.
+    :param text: LLM output that should contain JSON.
+    :return: String narrowed to the JSON region when delimiters exist.
     """
-    end = text.rfind("}")
-    if end != -1:
-        text = text[: end + 1]
+    object_start = text.find("{")
+    array_start = text.find("[")
 
-    start = text.find("{")
-    if start != -1:
+    starts = [idx for idx in (object_start, array_start) if idx != -1]
+    if not starts:
+        return text.strip()
+
+    start = min(starts)
+    opener = text[start]
+    closer = "}" if opener == "{" else "]"
+    end = text.rfind(closer)
+    if end != -1 and end >= start:
+        text = text[start: end + 1]
+    else:
         text = text[start:]
 
     return text.strip()
@@ -341,16 +371,19 @@ async def _call_with_validation(
 
         try:
             parsed = json.loads(content)
+            parsed = _normalize_parsed_response(parsed, schema_cls)
             validated = schema_cls.model_validate(parsed)
             return validated
         except (json.JSONDecodeError, ValidationError) as exc:
             last_error = exc
+            preview = content.replace("\n", "\\n")[:200]
             logger.warning(
-                "LLM response validation failed (attempt %d/%d): %s",
+                "LLM response validation failed (attempt %d/%d): %s; response preview=%r",
                 attempt + 1,
                 max_retries + 1,
                 # Truncate to avoid leaking excessive content in logs.
                 str(exc)[:300],
+                preview,
             )
             if attempt < max_retries:
                 # Inject correction hint as the first system message and retry.
@@ -768,30 +801,30 @@ async def generate_search_result_rationales(
 
         prompt = f"""You are writing short, personalized recommendation rationales for {list_type}.
 
-User query:
-\"{query}\"
-
-Interpreted filters:
-{json.dumps(discover_summary, ensure_ascii=True)}
-
-Generate one rationale for each candidate below:
-{json.dumps(input_items, ensure_ascii=True)}
-
-Return ONLY valid JSON with this exact shape:
-{{
-  \"rationales\": [
-    {{\"title\": \"...\", \"year\": 2020, \"rationale\": \"...\"}}
-  ]
-}}
-
-Rules:
-- Include exactly one entry per input item (same title/year pairs).
-- rationale must be exactly one sentence.
-- Keep each rationale natural, recommendation-like, and <= 20 words.
-- Vary wording across items; do not repeat the same sentence structure.
-- Mention concrete fit to the user's query or filters when possible.
-- Do not include markdown or any text outside JSON.
-"""
+        User query:
+        \"{query}\"
+        
+        Interpreted filters:
+        {json.dumps(discover_summary, ensure_ascii=True)}
+        
+        Generate one rationale for each candidate below:
+        {json.dumps(input_items, ensure_ascii=True)}
+        
+        Return ONLY valid JSON with this exact shape:
+        {{
+          \"rationales\": [
+            {{\"title\": \"...\", \"year\": 2020, \"rationale\": \"...\"}}
+          ]
+        }}
+        
+        Rules:
+        - Include exactly one entry per input item (same title/year pairs).
+        - rationale must be exactly one sentence.
+        - Keep each rationale natural, recommendation-like, and <= 20 words.
+        - Vary wording across items; do not repeat the same sentence structure.
+        - Mention concrete fit to the user's query or filters when possible.
+        - Do not include markdown or any text outside JSON.
+        """
 
         messages = [
             {

--- a/api_service/services/llm/llm_service.py
+++ b/api_service/services/llm/llm_service.py
@@ -11,6 +11,7 @@ All LLM calls go through :func:`_call_with_validation`, which:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from typing import Any, Dict, List, Optional, Type, TypeVar
@@ -41,6 +42,13 @@ _RETRY_SYSTEM_MESSAGE = (
     "Your previous response did not match the required JSON schema. "
     "Return strictly valid JSON matching the schema. "
     "No markdown fences, no extra fields, no comments."
+)
+
+_RECOMMENDATION_SCHEMA_HINT = (
+    'Required top-level shape: {"recommendations": ['
+    '{"title": "Movie title", "year": 2023, '
+    '"rationale": "Why this fits.", "source_title": "Watched title"}'
+    "]}. Do not return {}, an array, or any other top-level key."
 )
 
 
@@ -116,6 +124,27 @@ def is_llm_configured(config: Optional[Dict[str, Any]] = None) -> bool:
     api_key = cfg.get("OPENAI_API_KEY")
     base_url = cfg.get("OPENAI_BASE_URL")
     return bool(api_key or base_url)
+
+
+async def _close_llm_client(client: AsyncOpenAI) -> None:
+    """Close the LLM HTTP client and let transport callbacks finish."""
+    try:
+        await client.aclose()
+    except Exception as exc:
+        logger.debug("Ignoring LLM client close failure: %s", exc)
+        return
+
+    # httpx/anyio may schedule transport-close callbacks during aclose().
+    # Short-lived job loops must run those callbacks before loop.close().
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+def _validation_retry_message(schema_cls: Type[BaseModel]) -> str:
+    """Return schema-specific correction text for retry attempts."""
+    if schema_cls is RecommendationList:
+        return f"{_RETRY_SYSTEM_MESSAGE} {_RECOMMENDATION_SCHEMA_HINT}"
+    return _RETRY_SYSTEM_MESSAGE
 
 
 # ---------------------------------------------------------------------------
@@ -326,7 +355,7 @@ async def _call_with_validation(
             if attempt < max_retries:
                 # Inject correction hint as the first system message and retry.
                 current_messages = [
-                    {"role": "system", "content": _RETRY_SYSTEM_MESSAGE},
+                    {"role": "system", "content": _validation_retry_message(schema_cls)},
                     *messages,
                 ]
 
@@ -543,10 +572,7 @@ async def get_recommendations_from_history(
         logger.info("Successfully generated %d LLM recommendations.", len(valid_recommendations))
         return valid_recommendations[:max_results]
     finally:
-        try:
-            await client.aclose()
-        except Exception:
-            pass
+        await _close_llm_client(client)
 
 
 async def interpret_search_query(
@@ -685,10 +711,7 @@ Example format:
         )
         return result
     finally:
-        try:
-            await client.aclose()
-        except Exception:
-            pass
+        await _close_llm_client(client)
 
 
 async def generate_search_result_rationales(
@@ -803,7 +826,4 @@ Rules:
         logger.warning("Failed generating per-result LLM rationales: %s", exc)
         return {}
     finally:
-        try:
-            await client.aclose()
-        except Exception:
-            pass
+        await _close_llm_client(client)

--- a/api_service/services/seer/seer_client.py
+++ b/api_service/services/seer/seer_client.py
@@ -493,3 +493,37 @@ class SeerClient(BaseHTTPClient):
         """Retrieve metadata for a specific media item."""
         self.logger.debug("Getting metadata for media_id=%s, media_type=%s", media_id, media_type)
         return DatabaseManager().get_metadata(media_id, media_type)
+
+    async def lookup_seer_media_id(self, tmdb_id, media_type):
+        """Resolve TMDB id to Seer's internal mediaInfo.id (None if not present in Seer)."""
+        endpoint = f"api/v1/{'movie' if media_type == 'movie' else 'tv'}/{int(tmdb_id)}"
+        data = await self._make_request("GET", endpoint, use_cookie=bool(self.session_token))
+        if not data:
+            return None
+        media_info = data.get("mediaInfo") or {}
+        return media_info.get("id")
+
+    async def delete_media_file_by_tmdb(self, tmdb_id, media_type):
+        """Delete files (via arr) for the Seer media matching tmdb_id. Returns True on success."""
+        seer_media_id = await self.lookup_seer_media_id(tmdb_id, media_type)
+        if not seer_media_id:
+            self.logger.info("No Seer media found for tmdb_id=%s media_type=%s; nothing to delete.", tmdb_id, media_type)
+            return False
+        url = f"{self.api_url}/api/v1/media/{int(seer_media_id)}/file"
+        headers, cookies = self._get_auth_headers(bool(self.session_token))
+        session = await self._get_session()
+        try:
+            async with session.delete(url, headers=headers, cookies=cookies, timeout=self.REQUEST_TIMEOUT) as response:
+                if response.status in (200, 202, 204):
+                    self.logger.info("Deleted Seer media file for tmdb_id=%s (seer_media_id=%s)", tmdb_id, seer_media_id)
+                    return True
+                body = ""
+                try:
+                    body = await response.text()
+                except Exception:
+                    pass
+                self.logger.error("Failed to delete Seer media file: status=%s body=%s", response.status, body[:200])
+                return False
+        except aiohttp.ClientError as exc:
+            self.logger.error("Client error deleting Seer media file: %s", exc)
+            return False

--- a/api_service/services/seer/seer_client.py
+++ b/api_service/services/seer/seer_client.py
@@ -152,8 +152,12 @@ class SeerClient(BaseHTTPClient):
                     self.is_logged_in = True
                     self.logger.info("Successfully logged in as %s", self.username)
                 else:
+                    self.session_token = None
+                    self.is_logged_in = False
                     self.logger.error("Login failed: %d", response.status)
         except asyncio.TimeoutError:
+            self.session_token = None
+            self.is_logged_in = False
             self.logger.error("Login request to %s timed out.", login_url)
 
     async def get_all_users(self, max_users=100):
@@ -411,8 +415,18 @@ class SeerClient(BaseHTTPClient):
             return False
 
         self.logger.debug("Sending Jellyseerr request: %s", data)
-        if not self.session_token and self.username and self.password:
+        # Saved cookies can expire or belong to a previously selected user.
+        # Refresh when credentials exist so queued jobs run as the configured
+        # Jellyseerr user instead of silently falling back to a stale session.
+        if self.username and self.password:
             await self.login()
+            if not self.session_token:
+                self.logger.error(
+                    "Cannot submit Jellyseerr request for %s tmdb:%s — "
+                    "configured Seer user login failed. Re-authenticate the Seer user in settings.",
+                    media_type, media_id,
+                )
+                return False
 
         response = await self._make_request(
             "POST", "api/v1/request", data=data, use_cookie=bool(self.session_token)

--- a/api_service/test/test_frontend_routes.py
+++ b/api_service/test/test_frontend_routes.py
@@ -1,0 +1,109 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+from api_service.frontend_routes import normalize_subpath, register_routes
+
+
+class TestFrontendRoutes(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        static_root = self.tempdir.name
+        os.makedirs(os.path.join(static_root, "js"), exist_ok=True)
+        os.makedirs(os.path.join(static_root, "css"), exist_ok=True)
+
+        with open(os.path.join(static_root, "index.html"), "w", encoding="utf-8") as handle:
+            handle.write(
+                '<html><head></head><body>'
+                '<script src="js/app.123.js"></script>'
+                '<link href="css/app.123.css" rel="stylesheet">'
+                "</body></html>"
+            )
+
+        with open(os.path.join(static_root, "js", "app.123.js"), "w", encoding="utf-8") as handle:
+            handle.write("console.log('ok');")
+
+        with open(os.path.join(static_root, "css", "app.123.css"), "w", encoding="utf-8") as handle:
+            handle.write("body { color: red; }")
+
+        with open(os.path.join(static_root, "favicon.ico"), "wb") as handle:
+            handle.write(b"\x00\x00\x01\x00")
+
+        app = Flask(__name__, static_folder=static_root)
+        app.config["TESTING"] = True
+        register_routes(app)
+        self.client = app.test_client()
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_normalize_subpath_enforces_single_leading_slash(self):
+        self.assertEqual(normalize_subpath("suggestarr/"), "/suggestarr")
+        self.assertEqual(normalize_subpath("/suggestarr/"), "/suggestarr")
+        self.assertEqual(normalize_subpath(""), "")
+        self.assertEqual(normalize_subpath(None), "")
+
+    def test_subpath_root_returns_html_with_injected_tags(self):
+        with patch("api_service.frontend_routes.load_env_vars", return_value={"SUBPATH": "/suggestarr/"}):
+            response = self.client.get("/suggestarr/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/html", response.content_type)
+        body = response.get_data(as_text=True)
+        self.assertIn('<meta name="suggestarr-subpath" content="/suggestarr">', body)
+        self.assertIn('<base href="/suggestarr/">', body)
+        self.assertIn('src="js/app.123.js"', body)
+        self.assertIn('href="css/app.123.css"', body)
+
+    def test_subpath_js_asset_serves_javascript_not_html(self):
+        with patch("api_service.frontend_routes.load_env_vars", return_value={"SUBPATH": "/suggestarr"}):
+            response = self.client.get("/suggestarr/js/app.123.js")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("text/html", response.content_type)
+        self.assertIn("javascript", response.content_type)
+        self.assertEqual(response.get_data(as_text=True), "console.log('ok');")
+
+    def test_subpath_css_asset_serves_css_not_html(self):
+        with patch("api_service.frontend_routes.load_env_vars", return_value={"SUBPATH": "/suggestarr"}):
+            response = self.client.get("/suggestarr/css/app.123.css")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content_type, "text/css; charset=utf-8")
+        self.assertEqual(response.get_data(as_text=True), "body { color: red; }")
+
+    def test_missing_frontend_route_falls_back_to_index(self):
+        with patch("api_service.frontend_routes.load_env_vars", return_value={"SUBPATH": "/suggestarr"}):
+            response = self.client.get("/suggestarr/settings")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/html", response.content_type)
+        self.assertIn('<base href="/suggestarr/">', response.get_data(as_text=True))
+
+    def test_subpath_favicon_serves_file_not_html(self):
+        with patch("api_service.frontend_routes.load_env_vars", return_value={"SUBPATH": "/suggestarr"}):
+            response = self.client.get("/suggestarr/favicon.ico")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("text/html", response.content_type)
+        self.assertEqual(response.get_data(), b"\x00\x00\x01\x00")
+
+    def test_missing_asset_returns_404(self):
+        with patch("api_service.frontend_routes.load_env_vars", return_value={"SUBPATH": "/suggestarr"}):
+            response = self.client.get("/suggestarr/js/missing.js")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_root_deployment_asset_still_serves(self):
+        with patch("api_service.frontend_routes.load_env_vars", return_value={"SUBPATH": None}):
+            response = self.client.get("/js/app.123.js")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("javascript", response.content_type)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api_service/test/test_jobs_llm_routes.py
+++ b/api_service/test/test_jobs_llm_routes.py
@@ -55,7 +55,8 @@ class TestLlmConnectionRoute(unittest.TestCase):
             })
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(calls[0]['max_tokens'], 16)
+        self.assertEqual(calls[0]['max_completion_tokens'], 16)
+        self.assertNotIn('max_tokens', calls[0])
 
 
 class TestAsyncLoopCleanup(unittest.TestCase):

--- a/api_service/test/test_llm_service.py
+++ b/api_service/test/test_llm_service.py
@@ -313,6 +313,38 @@ class TestCallWithValidation(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(state["callback_ran"])
 
+    async def test_bare_recommendation_array_is_wrapped(self):
+        payload = json.dumps([
+            {"title": "Dune", "year": 2021, "rationale": "Epic.", "source_title": None}
+        ])
+        client = self._make_client(_mock_openai_response(payload))
+
+        result = await _call_with_validation(
+            client=client,
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "recommend"}],
+            schema_cls=RecommendationList,
+            max_retries=0,
+        )
+
+        self.assertEqual(result.recommendations[0].title, "Dune")
+
+    async def test_common_recommendation_keys_are_normalized(self):
+        payload = json.dumps({"movies": [
+            {"title": "Dune", "year": 2021, "rationale": "Epic.", "source_title": None}
+        ]})
+        client = self._make_client(_mock_openai_response(payload))
+
+        result = await _call_with_validation(
+            client=client,
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "recommend"}],
+            schema_cls=RecommendationList,
+            max_retries=0,
+        )
+
+        self.assertEqual(result.recommendations[0].title, "Dune")
+
     async def test_retries_exhausted_raises_llm_validation_error(self):
         bad_payload = json.dumps({"wrong_key": []})
         client = self._make_client(

--- a/api_service/test/test_llm_service.py
+++ b/api_service/test/test_llm_service.py
@@ -213,6 +213,12 @@ class TestCallWithValidation(unittest.IsolatedAsyncioTestCase):
         mock_client.chat.completions.create = AsyncMock(side_effect=list(responses))
         return mock_client
 
+    def _response_format_rejection(self, response_format_type: str):
+        exc = Exception(f"{response_format_type} response_format unsupported")
+        exc.status_code = 400
+        exc.body = {"error": f"{response_format_type} response_format unsupported"}
+        return exc
+
     async def test_valid_response_passes_first_attempt(self):
         payload = json.dumps({"recommendations": [
             {"title": "Dune", "year": 2021, "rationale": "Epic sci-fi", "source_title": None}
@@ -232,6 +238,30 @@ class TestCallWithValidation(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.recommendations[0].title, "Dune")
         # Only one API call should have been made
         self.assertEqual(client.chat.completions.create.call_count, 1)
+        response_format = client.chat.completions.create.call_args[1]["response_format"]
+        self.assertEqual(response_format["type"], "json_schema")
+
+    async def test_response_format_rejection_falls_back_without_burning_retry(self):
+        payload = json.dumps({"recommendations": [
+            {"title": "Dune", "year": 2021, "rationale": "Epic sci-fi", "source_title": None}
+        ]})
+        client = self._make_client(
+            self._response_format_rejection("json_schema"),
+            _mock_openai_response(payload),
+        )
+
+        result = await _call_with_validation(
+            client=client,
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "recommend"}],
+            schema_cls=RecommendationList,
+            max_retries=0,
+        )
+
+        self.assertEqual(result.recommendations[0].title, "Dune")
+        self.assertEqual(client.chat.completions.create.call_count, 2)
+        second_response_format = client.chat.completions.create.call_args_list[1][1]["response_format"]
+        self.assertEqual(second_response_format["type"], "json_object")
 
     async def test_invalid_schema_triggers_retry_and_succeeds(self):
         bad_payload = json.dumps({"wrong_key": []})  # missing "recommendations"

--- a/api_service/test/test_llm_service.py
+++ b/api_service/test/test_llm_service.py
@@ -29,12 +29,14 @@ Covers (interpret_search_query — async):
 """
 
 import json
+import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from api_service.exceptions.api_exceptions import LLMValidationError
 from api_service.services.llm.llm_service import (
     _call_with_validation,
+    _close_llm_client,
     _deduplicate_history,
     _extract_json_object,
     _is_duplicate_of_history,
@@ -276,6 +278,40 @@ class TestCallWithValidation(unittest.IsolatedAsyncioTestCase):
         second_call_messages = client.chat.completions.create.call_args_list[1][1]["messages"]
         self.assertEqual(second_call_messages[0]["role"], "system")
         self.assertIn("schema", second_call_messages[0]["content"].lower())
+
+    async def test_recommendation_retry_includes_required_top_level_shape(self):
+        bad_payload = json.dumps({})
+        good_payload = json.dumps({"recommendations": [
+            {"title": "Tenet", "year": 2020, "rationale": "Great.", "source_title": None}
+        ]})
+        client = self._make_client(
+            _mock_openai_response(bad_payload),
+            _mock_openai_response(good_payload),
+        )
+
+        await _call_with_validation(
+            client=client,
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "recommend"}],
+            schema_cls=RecommendationList,
+            max_retries=1,
+        )
+
+        second_call_messages = client.chat.completions.create.call_args_list[1][1]["messages"]
+        self.assertIn('"recommendations"', second_call_messages[0]["content"])
+        self.assertIn("Do not return {}", second_call_messages[0]["content"])
+
+    async def test_close_llm_client_drains_transport_close_callbacks(self):
+        state = {"callback_ran": False}
+
+        class FakeClient:
+            async def aclose(self):
+                loop = asyncio.get_running_loop()
+                loop.call_soon(lambda: state.__setitem__("callback_ran", True))
+
+        await _close_llm_client(FakeClient())
+
+        self.assertTrue(state["callback_ran"])
 
     async def test_retries_exhausted_raises_llm_validation_error(self):
         bad_payload = json.dumps({"wrong_key": []})

--- a/api_service/test/test_seer_client.py
+++ b/api_service/test/test_seer_client.py
@@ -593,10 +593,12 @@ class TestSubmitQueuedRequest(unittest.IsolatedAsyncioTestCase):
     async def test_strips_private_keys_and_returns_true_on_success(self):
         client = _make_client(session_token='tok')
         payload = self._valid_payload()
-        with patch.object(client, '_make_request', AsyncMock(return_value={'id': 55})) as mock_req:
+        with patch.object(client, 'login', AsyncMock()) as mock_login, \
+             patch.object(client, '_make_request', AsyncMock(return_value={'id': 55})) as mock_req:
             result = await client.submit_queued_request(payload)
 
         self.assertTrue(result)
+        mock_login.assert_awaited_once()
         sent_data = mock_req.call_args[1]['data']
         for key in sent_data:
             self.assertFalse(key.startswith('_'), f"Private key {key!r} was not stripped")
@@ -616,9 +618,40 @@ class TestSubmitQueuedRequest(unittest.IsolatedAsyncioTestCase):
         mock_login.assert_awaited_once()
         self.assertTrue(mock_req.call_args.kwargs['use_cookie'])
 
+    async def test_refreshes_login_before_submit_when_session_token_exists(self):
+        client = _make_client(session_token='stale-token')
+        payload = self._valid_payload()
+
+        async def login():
+            client.session_token = 'fresh-token'
+
+        with patch.object(client, 'login', AsyncMock(side_effect=login)) as mock_login, \
+             patch.object(client, '_make_request', AsyncMock(return_value={'id': 55})) as mock_req:
+            result = await client.submit_queued_request(payload)
+
+        self.assertTrue(result)
+        mock_login.assert_awaited_once()
+        self.assertTrue(mock_req.call_args.kwargs['use_cookie'])
+        self.assertEqual(client.session_token, 'fresh-token')
+
+    async def test_returns_false_when_configured_user_login_fails(self):
+        client = _make_client(session_token='stale-token')
+
+        async def login():
+            client.session_token = None
+
+        with patch.object(client, 'login', AsyncMock(side_effect=login)) as mock_login, \
+             patch.object(client, '_make_request', AsyncMock()) as mock_req:
+            result = await client.submit_queued_request(self._valid_payload())
+
+        self.assertFalse(result)
+        mock_login.assert_awaited_once()
+        mock_req.assert_not_awaited()
+
     async def test_returns_false_on_failure_response(self):
         client = _make_client(session_token='tok')
-        with patch.object(client, '_make_request', AsyncMock(return_value=None)), \
+        with patch.object(client, 'login', AsyncMock()), \
+             patch.object(client, '_make_request', AsyncMock(return_value=None)), \
              patch.object(client, '_fetch_server_defaults', AsyncMock(return_value={'profileId': 1, 'rootFolder': '/movies'})):
             result = await client.submit_queued_request({'mediaType': 'movie', 'mediaId': 1})
         self.assertFalse(result)
@@ -628,6 +661,7 @@ class TestSubmitQueuedRequest(unittest.IsolatedAsyncioTestCase):
         payload = {'mediaType': 'movie', 'mediaId': 200, 'serverId': 0}
         defaults = {'profileId': 3, 'rootFolder': '/movies'}
         with patch.object(client, '_fetch_server_defaults', AsyncMock(return_value=defaults)), \
+             patch.object(client, 'login', AsyncMock()), \
              patch.object(client, '_make_request', AsyncMock(return_value={'id': 200})):
             result = await client.submit_queued_request(payload)
         self.assertTrue(result)
@@ -650,7 +684,8 @@ class TestSubmitQueuedRequest(unittest.IsolatedAsyncioTestCase):
 
     async def test_returns_false_on_error_response(self):
         client = _make_client(session_token='tok')
-        with patch.object(client, '_make_request', AsyncMock(return_value={'error': 'Bad Request'})):
+        with patch.object(client, 'login', AsyncMock()), \
+             patch.object(client, '_make_request', AsyncMock(return_value={'error': 'Bad Request'})):
             result = await client.submit_queued_request(self._valid_payload())
         self.assertFalse(result)
 
@@ -658,6 +693,7 @@ class TestSubmitQueuedRequest(unittest.IsolatedAsyncioTestCase):
         """_fetch_server_defaults must not be called when profileId and rootFolder are set."""
         client = _make_client(session_token='tok')
         with patch.object(client, '_fetch_server_defaults', AsyncMock()) as mock_fallback, \
+             patch.object(client, 'login', AsyncMock()), \
              patch.object(client, '_make_request', AsyncMock(return_value={'id': 1})):
             await client.submit_queued_request(self._valid_payload())
         mock_fallback.assert_not_called()

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suggestarr",
-  "version": "v2.7.2",
+  "version": "v2.7.3",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suggestarr",
-  "version": "v2.7.1",
+  "version": "v2.7.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -132,6 +132,13 @@ export const aiSearchStatus = () => {
     return axios.get('/api/ai-search/status');
 };
 
+
+// Cleanup automation
+export const getCleanupSettings = () => axios.get('/api/cleanup/settings');
+export const setCleanupSettings = (payload) => axios.post('/api/cleanup/settings', payload);
+export const runCleanupNow = (dryRun = null) => axios.post('/api/cleanup/run', dryRun === null ? {} : { dry_run: dryRun });
+export const getCleanupLog = (limit = 100) => axios.get('/api/cleanup/log', { params: { limit } });
+
 // Config export: download a full configuration snapshot (admin only, includes API keys)
 export const exportConfig = () => {
     return axios.get('/api/config/export', { responseType: 'json' });

--- a/client/src/components/DashboardPage.vue
+++ b/client/src/components/DashboardPage.vue
@@ -341,6 +341,7 @@ import SettingsAdvanced from './settings/SettingsAdvanced.vue';
 import SettingsRequests from './settings/SettingsRequests.vue';
 import SettingsJobs from './settings/SettingsJobs.vue';
 import AiSearchPage from './settings/AiSearchPage.vue';
+import SettingsCleanup from './settings/SettingsCleanup.vue';
 import LogsComponent from './LogsComponent.vue';
 import UserManagement from './settings/UserManagement.vue';
 import UserProfile from './settings/UserProfile.vue';
@@ -359,6 +360,7 @@ export default {
     SettingsRequests,
     SettingsJobs,
     AiSearchPage,
+    SettingsCleanup,
     LogsComponent,
     UserManagement,
     UserProfile,
@@ -417,6 +419,7 @@ export default {
         { id: 'jobs',      name: 'Jobs',       icon: 'fas fa-briefcase',   tourId: 'tab-jobs' },
         { id: 'database',  name: 'Database',  icon: 'fas fa-database',     tourId: 'tab-database', adminOnly: true },
         { id: 'advanced',  name: 'Advanced',  icon: 'fas fa-sliders-h',   tourId: 'tab-advanced', adminOnly: true },
+        { id: 'cleanup',   name: 'Cleanup',   icon: 'fas fa-broom',       tourId: 'tab-cleanup', adminOnly: true },
         { id: 'users',     name: 'Users',      icon: 'fas fa-users',       adminOnly: true },
         { id: 'profile',   name: 'Profile',    icon: 'fas fa-user-circle', nonAdminOnly: true },
         { id: 'logs',      name: 'Logs',       icon: 'fas fa-file-alt',    tourId: 'tab-logs', adminOnly: true },
@@ -522,6 +525,7 @@ export default {
         advanced: 'SettingsAdvanced',
         logs: 'LogsComponent',
         ai_search: 'AiSearchPage',
+        cleanup: 'SettingsCleanup',
         users: 'UserManagement',
         profile: 'UserProfile',
       };

--- a/client/src/components/settings/SettingsCleanup.vue
+++ b/client/src/components/settings/SettingsCleanup.vue
@@ -1,0 +1,286 @@
+<template>
+  <div class="cleanup-page">
+    <div class="section-header">
+      <h2><i class="fas fa-broom"></i> Cleanup Automation</h2>
+      <p>Automatically delete SuggestArr requests and their files when the item has not been favorited (Plex heart) within a grace period.</p>
+    </div>
+
+    <div class="warning-banner">
+      <i class="fas fa-exclamation-triangle"></i>
+      <div class="warning-content">
+        <strong>Destructive action</strong>
+        <span>When enabled and not in dry-run, this will delete media files via Radarr/Sonarr (through Seer). Always run in dry-run first to verify the candidate list.</span>
+      </div>
+    </div>
+
+    <div v-if="loading" class="placeholder">Loading…</div>
+
+    <div v-else class="settings-card">
+      <label class="toggle-option">
+        <span class="toggle-label">
+          <i class="fas fa-power-off"></i>
+          Enable cleanup automation
+          <span class="toggle-hint">Runs daily at 04:15 server-time. When off, no scans happen.</span>
+        </span>
+        <div class="toggle-switch" :class="{ on: form.enabled }" @click="form.enabled = !form.enabled">
+          <div class="toggle-knob"></div>
+        </div>
+      </label>
+
+      <label class="toggle-option">
+        <span class="toggle-label">
+          <i class="fas fa-vial"></i>
+          Dry-run mode
+          <span class="toggle-hint">Logs what would be deleted without actually touching files. Strongly recommended before flipping to real deletion.</span>
+        </span>
+        <div class="toggle-switch" :class="{ on: form.dry_run }" @click="form.dry_run = !form.dry_run">
+          <div class="toggle-knob"></div>
+        </div>
+      </label>
+
+      <div class="number-option">
+        <span class="toggle-label">
+          <i class="fas fa-hourglass-half"></i>
+          Grace period (days)
+          <span class="toggle-hint">If a requested item has not been favorited (Plex heart) within this many days of being requested, it becomes a deletion candidate.</span>
+        </span>
+        <input v-model.number="form.grace_days" type="number" min="1" max="365" class="number-input" />
+      </div>
+
+      <div class="actions-row">
+        <button class="btn btn-primary" :disabled="saving" @click="save">
+          <i :class="saving ? 'fas fa-spinner fa-spin' : 'fas fa-save'"></i>
+          {{ saving ? 'Saving…' : 'Save settings' }}
+        </button>
+        <button class="btn" :disabled="running" @click="runNow(true)">
+          <i :class="running && lastTrigger === 'dry' ? 'fas fa-spinner fa-spin' : 'fas fa-vial'"></i>
+          Run now (dry-run)
+        </button>
+        <button class="btn btn-danger" :disabled="running || !form.enabled" @click="runNow(false)" title="Performs real deletions">
+          <i :class="running && lastTrigger === 'real' ? 'fas fa-spinner fa-spin' : 'fas fa-trash-alt'"></i>
+          Run now (real)
+        </button>
+      </div>
+
+      <div v-if="lastResult" class="result-banner" :class="{ ok: lastResult.status === 'success', err: lastResult.status === 'error' }">
+        <i :class="lastResult.status === 'success' ? 'fas fa-check-circle' : 'fas fa-exclamation-circle'"></i>
+        <span>{{ lastResult.message }}</span>
+      </div>
+
+      <div v-if="settings && settings.last_run_at" class="last-run-info">
+        <span><strong>Last run:</strong> {{ formatTs(settings.last_run_at) }} · {{ settings.last_run_status || '—' }}</span>
+        <div v-if="settings.last_run_summary" class="last-run-summary">{{ settings.last_run_summary }}</div>
+      </div>
+    </div>
+
+    <div class="settings-card">
+      <div class="card-header-row">
+        <h3><i class="fas fa-history"></i> Audit log</h3>
+        <button class="btn btn-link" @click="loadLog" :disabled="loadingLog">
+          <i :class="loadingLog ? 'fas fa-spinner fa-spin' : 'fas fa-sync'"></i> Refresh
+        </button>
+      </div>
+      <div v-if="!log.length" class="placeholder">No cleanup actions logged yet.</div>
+      <table v-else class="log-table">
+        <thead>
+          <tr>
+            <th>When</th>
+            <th>Title</th>
+            <th>Type</th>
+            <th>Action</th>
+            <th>Mode</th>
+            <th>★</th>
+            <th>Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in log" :key="row.id" :class="actionClass(row.action)">
+            <td>{{ formatTs(row.ran_at) }}</td>
+            <td>{{ row.title || ('tmdb:' + row.tmdb_id) }}</td>
+            <td>{{ row.media_type === 'tv' ? 'TV' : 'Movie' }}</td>
+            <td>{{ row.action }}</td>
+            <td>{{ row.was_dry_run ? 'dry' : 'real' }}</td>
+            <td>{{ row.user_rating ?? '—' }}</td>
+            <td>{{ row.reason }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import { getCleanupSettings, setCleanupSettings, runCleanupNow, getCleanupLog } from '@/api/api.js';
+
+export default {
+  name: 'SettingsCleanup',
+
+  data() {
+    return {
+      loading: true,
+      loadingLog: false,
+      saving: false,
+      running: false,
+      lastTrigger: null,
+      settings: null,
+      form: { enabled: false, dry_run: true, grace_days: 7 },
+      log: [],
+      lastResult: null,
+    };
+  },
+
+  methods: {
+    async loadSettings() {
+      this.loading = true;
+      try {
+        const res = await getCleanupSettings();
+        this.settings = res.data.settings;
+        this.form = {
+          enabled: !!this.settings.enabled,
+          dry_run: !!this.settings.dry_run,
+          grace_days: Number(this.settings.grace_days) || 7,
+        };
+      } catch (err) {
+        this.lastResult = { status: 'error', message: err.response?.data?.message || 'Failed to load settings.' };
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async save() {
+      this.saving = true;
+      this.lastResult = null;
+      try {
+        const res = await setCleanupSettings(this.form);
+        this.settings = res.data.settings;
+        this.lastResult = { status: 'success', message: 'Settings saved.' };
+      } catch (err) {
+        this.lastResult = { status: 'error', message: err.response?.data?.message || 'Failed to save.' };
+      } finally {
+        this.saving = false;
+      }
+    },
+
+    async runNow(dryRun) {
+      if (this.running) return;
+      this.running = true;
+      this.lastTrigger = dryRun ? 'dry' : 'real';
+      this.lastResult = null;
+      try {
+        const res = await runCleanupNow(dryRun);
+        const r = res.data.result || {};
+        this.lastResult = { status: 'success', message: `Run complete (${dryRun ? 'dry-run' : 'real'}): ${r.summary || r.message || 'done'}` };
+        await this.loadSettings();
+        await this.loadLog();
+      } catch (err) {
+        this.lastResult = { status: 'error', message: err.response?.data?.message || 'Run failed.' };
+      } finally {
+        this.running = false;
+        this.lastTrigger = null;
+      }
+    },
+
+    async loadLog() {
+      this.loadingLog = true;
+      try {
+        const res = await getCleanupLog(200);
+        this.log = res.data.log || [];
+      } catch (err) {
+        // non-fatal
+      } finally {
+        this.loadingLog = false;
+      }
+    },
+
+    formatTs(ts) {
+      if (!ts) return '—';
+      try {
+        return new Date(ts.endsWith('Z') ? ts : ts + 'Z').toLocaleString();
+      } catch {
+        return ts;
+      }
+    },
+
+    actionClass(action) {
+      if (action === 'deleted' || action === 'would_delete') return 'row-delete';
+      if (action === 'kept_favorited') return 'row-kept';
+      if (action === 'error' || action === 'delete_failed') return 'row-error';
+      return '';
+    },
+  },
+
+  mounted() {
+    this.loadSettings();
+    this.loadLog();
+  },
+};
+</script>
+
+<style scoped>
+.cleanup-page { padding: 0; }
+.section-header h2 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+.section-header p { color: var(--color-text-muted, #aaa); }
+
+.warning-banner {
+  display: flex; gap: 12px; align-items: flex-start;
+  background: rgba(231, 138, 0, 0.1); border: 1px solid rgba(231, 138, 0, 0.4);
+  padding: 12px; border-radius: 8px; margin: 16px 0;
+}
+.warning-banner i { color: #e78a00; font-size: 1.1rem; margin-top: 2px; }
+.warning-content strong { display: block; margin-bottom: 2px; }
+
+.settings-card {
+  background: var(--color-card, #2a2a2a);
+  border: 1px solid var(--color-border, #444);
+  border-radius: 8px; padding: 16px; margin-bottom: 20px;
+}
+
+.toggle-option, .number-option {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 0; border-bottom: 1px solid var(--color-border-soft, #333);
+}
+.toggle-option:last-of-type, .number-option:last-of-type { border-bottom: none; }
+.toggle-label { display: flex; flex-direction: column; gap: 4px; max-width: 70%; }
+.toggle-hint { color: var(--color-text-muted, #888); font-size: 0.85rem; }
+
+.number-input {
+  width: 90px; padding: 6px 8px;
+  background: var(--color-bg, #1f1f1f); border: 1px solid var(--color-border, #444);
+  border-radius: 6px; color: var(--color-text-primary, white);
+}
+
+.actions-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+.btn {
+  padding: 8px 14px; border-radius: 6px; cursor: pointer; font-size: 0.9rem;
+  border: 1px solid var(--color-border, #444); background: transparent; color: var(--color-text-primary, #ddd);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.btn:hover:not(:disabled) { border-color: #888; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-primary { background: #3498db; border-color: #3498db; color: white; }
+.btn-danger { background: #c0392b; border-color: #c0392b; color: white; }
+.btn-link { background: transparent; border: none; color: #3498db; padding: 4px 8px; }
+
+.result-banner {
+  margin-top: 12px; padding: 10px; border-radius: 6px;
+  display: flex; gap: 8px; align-items: center;
+}
+.result-banner.ok { background: rgba(46, 204, 113, 0.12); border: 1px solid #2ecc71; color: #2ecc71; }
+.result-banner.err { background: rgba(231, 76, 60, 0.12); border: 1px solid #e74c3c; color: #e74c3c; }
+
+.last-run-info { margin-top: 12px; font-size: 0.9rem; color: var(--color-text-muted, #aaa); }
+.last-run-summary { margin-top: 4px; font-family: monospace; font-size: 0.82rem; }
+
+.card-header-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.placeholder { color: var(--color-text-muted, #888); padding: 8px 0; font-style: italic; }
+
+.log-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.log-table th, .log-table td {
+  text-align: left; padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border-soft, #333);
+}
+.log-table th { color: var(--color-text-muted, #aaa); font-weight: 600; }
+.log-table .row-delete { color: #e67e22; }
+.log-table .row-kept { color: #2ecc71; }
+.log-table .row-error { color: #e74c3c; }
+</style>


### PR DESCRIPTION
> ⚠️ **Disclosure:** This PR was generated with AI assistance (Claude) and then reviewed, tested locally, and verified by a human before submission. Please flag anything that looks off.

## Why this is needed

Once a SuggestArr request lands, gets approved, and is downloaded, there is nothing automatic that ever cleans it back up if the user didn't actually want it. Over time this adds up to substantial library bloat — titles the user requested a single time on a whim, watched part of, never starred, and never deleted. Tools like Deleterr exist but require a parallel deployment, and they have no awareness of which media originated from SuggestArr vs. from the user's own activity.

This PR adds an opt-in cleanup automation that uses an explicit user signal — the **Plex heart / "Like" (`userRating == 10`)** — as a "I am keeping this" marker. Anything SuggestArr requested that hasn't been hearted within a configurable grace period becomes a deletion candidate.

## What it does

Once a day (cron 04:15 server-time, when enabled), scan all SuggestArr-originated requests older than the configured grace period (default 7 days). For each:

1. Look up the matching item in Plex by TMDB GUID.
2. Read its `userRating`.
3. If `userRating >= 10` → **keep forever**, log `kept_favorited`.
4. If not in the Plex library at all → log `skipped_not_in_library` (nothing to delete).
5. Otherwise → **deletion candidate**.
6. In **dry-run** mode: log `would_delete` and stop.
7. In **real** mode: call Seer's `DELETE /api/v1/media/{seerMediaId}/file`, which propagates to Radarr/Sonarr (file leaves disk, arr DB stays in sync). The matching row in SuggestArr's `requests` table is also removed. Log `deleted` (or `delete_failed`/`error`).

## Safe by default

- Setting starts **disabled**. Nothing runs until an admin toggles it on.
- Even when enabled, **dry-run is on by default** — every "would-delete" decision is written to the audit log without any file ever being touched. Flipping to real deletion is a second, independent toggle.
- Grace period is configurable (1–365 days, default 7).
- Per-action audit log surfaces title, action, dry-vs-real, observed `userRating`, and the reason for each decision.
- Manual **"Run now (dry-run)"** button alongside **"Run now (real)"** — the real-mode button is disabled unless the automation is enabled.

## What changed

**Frontend**
- New admin-only **Cleanup** tab (icon: broom).
- Settings card: enable toggle, dry-run toggle, grace-days input, save.
- Action buttons: dry-run now / real now.
- Last-run summary banner.
- Audit-log table with action-coloured rows.

**Backend**
- New tables: `cleanup_settings` (singleton) and `cleanup_log`.
- New blueprint `cleanup_bp` mounted at `/api/cleanup`:
  - `GET  /api/cleanup/settings`
  - `POST /api/cleanup/settings`  `{enabled?, dry_run?, grace_days?}`
  - `POST /api/cleanup/run`        optional `{dry_run}` override for one-shot runs
  - `GET  /api/cleanup/log?limit=`
- New `SeerClient` helpers: `lookup_seer_media_id` (TMDB → Seer media id) and `delete_media_file_by_tmdb` (calls Seer's destructive delete).
- New job `api_service.jobs.cleanup_automation.execute_cleanup_job` registered as a daily APScheduler cron alongside the existing recommendation / queue-worker jobs.

## Design choices

- **Plex heart is the explicit "keep" signal** — watch state is intentionally NOT used. Watching once doesn't mean wanting to keep.
- **Only SuggestArr-originated requests are touched** — `requested_by = 'SuggestArr'` filter in every cleanup query. Items the user requested manually via Seer are never affected.
- **All destructive paths go through Seer**, so Radarr/Sonarr stay authoritative; we never touch files on disk directly.
- **Per `media_type` lookup** so a TV show and a movie sharing a TMDB id never collide.
- **Audit log writes are best-effort** — wrapped in try/except so a DB hiccup never breaks a cleanup pass.
- **Daily cron** rather than per-request, to keep load minimal and the audit log tidy.

## Test plan

- [x] Cleanup tab is hidden for non-admin users.
- [x] Default state: disabled, dry-run on, 7 days. Save persists to DB.
- [x] `GET /api/cleanup/settings` returns the singleton row.
- [x] `POST /api/cleanup/settings` updates `enabled` / `dry_run` / `grace_days`.
- [x] `POST /api/cleanup/run` returns `{status: 'ok', summary: 'No requests older than N days.'}` when nothing is eligible.
- [ ] Run with eligible candidates → audit log shows `kept_favorited` / `would_delete` / `skipped_not_in_library` rows. *(not yet exercised — local repo had no requests older than 7 days at the time of testing)*
- [ ] Real-mode delete propagates to Radarr/Sonarr and removes the local request row. *(deferred until a real candidate exists)*
- [x] Daily cron is registered (visible in startup log: `Jobs scheduler initialized (… + cleanup)`).
- [x] Unauthenticated requests to all new endpoints return 401.

## Backwards compatibility

- Both new tables created on next startup via the standard `initialize_db` path.
- No config schema change; no new env var required.
- The cron job is no-op when `cleanup_settings.enabled = false` (the default).
