### PR TITLE
feat: Trakt integration — profile-based architecture with admin UI and automation augmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,5 +379,9 @@ config/suggestarr.db
 client/package-lock.json
 static/
 
+# AI agent planning artifacts (ephemeral)
+docs/superpowers/plans/
+branch-review-findings.md
+
 # macOS
 .DS_Store

--- a/api_service/app.py
+++ b/api_service/app.py
@@ -33,6 +33,7 @@ from api_service.blueprints.health.routes import health_bp
 from api_service.blueprints.admin.routes import admin_bp
 from api_service.blueprints.users.routes import users_bp
 from api_service.blueprints.cleanup.routes import cleanup_bp
+from api_service.blueprints.trakt.routes import trakt_bp
 
 class SubpathMiddleware:
     """
@@ -187,6 +188,7 @@ def create_app():
     application.register_blueprint(admin_bp, url_prefix='/api/admin')
     application.register_blueprint(users_bp, url_prefix='/api/users')
     application.register_blueprint(cleanup_bp, url_prefix='/api/cleanup')
+    application.register_blueprint(trakt_bp, url_prefix='/api/trakt')
 
     # Register routes
     register_routes(application)

--- a/api_service/automate_process.py
+++ b/api_service/automate_process.py
@@ -7,6 +7,7 @@ from api_service.services.seer.seer_client import SeerClient
 from api_service.services.omdb.omdb_client import OmdbClient
 from api_service.services.plex.plex_client import PlexClient
 from api_service.services.tmdb.tmdb_client import TMDbClient
+from api_service.services.trakt.media_user_augmentor import MediaUserTraktAugmentor
 
 
 class ContentAutomation:
@@ -149,6 +150,9 @@ class ContentAutomation:
         )
         instance.logger.info("TMDb client initialized successfully")
 
+        # Build Trakt augmentor (no-op if app credentials are not configured)
+        trakt_augmentor = MediaUserTraktAugmentor.from_env(env_vars, instance.max_content)
+
         # Initialize media service handler (Jellyfin or Plex)
         if instance.selected_service in ('jellyfin', 'emby'):
             instance.logger.info(f"Initializing {instance.selected_service.upper()} client")
@@ -177,7 +181,9 @@ class ContentAutomation:
                 jellyfin_client, seer_client, tmdb_client, instance.logger,
                 instance.max_similar_movie, instance.max_similar_tv,
                 instance.selected_users, jellyfin_anime_map,
-                request_delay=request_delay
+                request_delay=request_delay,
+                trakt_augmentor=trakt_augmentor,
+                max_content=instance.max_content,
             )
             instance.logger.info(f"{instance.selected_service.upper()} client initialized successfully")
 
@@ -208,9 +214,13 @@ class ContentAutomation:
             instance.media_handler = PlexHandler(
                 plex_client, seer_client, tmdb_client, instance.logger,
                 instance.max_similar_movie, instance.max_similar_tv,
-                plex_anime_map, request_delay=request_delay
+                plex_anime_map, request_delay=request_delay,
+                trakt_augmentor=trakt_augmentor,
+                selected_users=instance.selected_users,
+                max_content=instance.max_content,
             )
             instance.logger.info("Plex client initialized successfully")
+
         else:
             instance.logger.warning(f"Unknown selected service: {instance.selected_service}")
             raise ValueError(f"Unsupported service: {instance.selected_service}")
@@ -241,4 +251,3 @@ class ContentAutomation:
         except Exception as e:
             self.logger.error(f"Content automation process failed: {str(e)}", exc_info=True)
             raise
-

--- a/api_service/blueprints/admin/routes.py
+++ b/api_service/blueprints/admin/routes.py
@@ -24,7 +24,7 @@ admin_bp = Blueprint('admin', __name__)
 # Substring patterns used to identify secret fields inside integration configs.
 # Any integration config key whose name contains one of these strings is treated
 # as sensitive and stripped when include_secrets=false.
-_INTEGRATION_SECRET_PATTERNS = ('token', 'api_key', 'password')
+_INTEGRATION_SECRET_PATTERNS = ('token', 'api_key', 'password', 'secret')
 
 # Top-level keys in the settings dict (config.yaml) that hold secrets.
 _SETTINGS_SECRET_KEYS = frozenset({

--- a/api_service/blueprints/config/routes.py
+++ b/api_service/blueprints/config/routes.py
@@ -279,6 +279,7 @@ def get_setup_status():
             'is_complete': is_complete,
             'selected_service': config.get('SELECTED_SERVICE'),
             'has_tmdb_key': bool(config.get('TMDB_API_KEY')),
+            'trakt_app_configured': bool(config.get('TRAKT_CLIENT_ID') and config.get('TRAKT_CLIENT_SECRET')),
             'status': 'success'
         }), 200
     except Exception as e:

--- a/api_service/blueprints/trakt/__init__.py
+++ b/api_service/blueprints/trakt/__init__.py
@@ -1,0 +1,3 @@
+"""Trakt blueprint package."""
+
+from .routes import trakt_bp

--- a/api_service/blueprints/trakt/routes.py
+++ b/api_service/blueprints/trakt/routes.py
@@ -1,0 +1,323 @@
+from typing import Any, Optional
+
+from asgiref.sync import async_to_sync
+from flask import Blueprint, jsonify, request
+
+from api_service.auth.middleware import require_role
+from api_service.config.config import load_env_vars
+from api_service.config.logger_manager import LoggerManager
+from api_service.db.database_manager import DatabaseManager
+from api_service.services.config_service import ConfigService
+from api_service.services.trakt.trakt_client import (
+    TraktClient,
+    TraktDeviceDenied,
+    TraktDeviceExpired,
+    TraktDevicePending,
+)
+
+logger = LoggerManager.get_logger("TraktRoute")
+trakt_bp = Blueprint("trakt", __name__)
+
+
+def _get_json() -> dict:
+    """Return the request JSON payload or an empty dict."""
+    return request.get_json(silent=True) or {}
+
+
+def _trakt_credentials_from_payload(payload: dict) -> tuple[str, str]:
+    """Extract app-level Trakt OAuth credentials from accepted payload keys."""
+    client_id = payload.get("client_id") or payload.get("TRAKT_CLIENT_ID") or ""
+    client_secret = payload.get("client_secret") or payload.get("TRAKT_CLIENT_SECRET") or ""
+    return str(client_id).strip(), str(client_secret).strip()
+
+
+def _trakt_credentials_from_config() -> tuple[str, str]:
+    """Extract app-level Trakt OAuth credentials from runtime configuration."""
+    config = ConfigService.get_runtime_config()
+    integrations = config.get("integrations") if isinstance(config.get("integrations"), dict) else {}
+    trakt_config = integrations.get("trakt") if isinstance(integrations.get("trakt"), dict) else {}
+    client_id = config.get("TRAKT_CLIENT_ID") or trakt_config.get("client_id") or ""
+    client_secret = config.get("TRAKT_CLIENT_SECRET") or trakt_config.get("client_secret") or ""
+    return str(client_id).strip(), str(client_secret).strip()
+
+
+def _resolve_trakt_credentials(payload: dict) -> tuple[str, str, bool]:
+    """Resolve app-level Trakt OAuth credentials.
+
+    Returns:
+        tuple: client_id, client_secret, whether both values came from payload.
+    """
+    payload_client_id, payload_client_secret = _trakt_credentials_from_payload(payload)
+    if payload_client_id and payload_client_secret:
+        return payload_client_id, payload_client_secret, True
+
+    config_client_id, config_client_secret = _trakt_credentials_from_config()
+    return config_client_id, config_client_secret, False
+
+
+def _save_app_credentials_if_supplied(db: DatabaseManager, client_id: str, client_secret: str, from_payload: bool) -> None:
+    """Persist only app-level Trakt OAuth credentials when explicitly supplied."""
+    if from_payload:
+        db.set_integration("trakt", {
+            "client_id": client_id,
+            "client_secret": client_secret,
+        })
+
+
+def _selected_provider() -> str:
+    """Return the configured media-server provider (lowercased)."""
+    config = load_env_vars()
+    return str(config.get("SELECTED_SERVICE") or "").lower()
+
+
+def _selected_media_users() -> list[dict]:
+    """Return the configured media-server users as a list of dicts."""
+    config = load_env_vars()
+    users = config.get("SELECTED_USERS") or []
+    return [u for u in users if isinstance(u, dict)]
+
+
+def _find_selected_user(provider: str, external_user_id: str) -> Optional[dict]:
+    """Return the matching media user, or None when provider/user is unknown.
+
+    The provider must match the configured ``SELECTED_SERVICE`` and the id must
+    appear in ``SELECTED_USERS``; otherwise the target is treated as unknown.
+    """
+    if provider.lower() != _selected_provider():
+        return None
+    for user in _selected_media_users():
+        if str(user.get("id")) == str(external_user_id):
+            return user
+    return None
+
+
+async def _request_device_code(client_id: str, client_secret: str, db: DatabaseManager) -> dict[str, Any]:
+    """Request a Trakt device-code activation payload."""
+    async with TraktClient(client_id, client_secret, db=db) as client:
+        return await client.request_device_code()
+
+
+async def _poll_device_token(
+    client_id: str,
+    client_secret: str,
+    device_code: str,
+    db: DatabaseManager,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Exchange a device code and fetch authenticated Trakt account metadata.
+
+    The client is constructed WITHOUT provider/external_user_id so the initial
+    token exchange does not attempt to persist via ``update_media_user_trakt_tokens``
+    (a guaranteed 0-row UPDATE before the account row exists). The caller's
+    ``upsert_media_user_trakt_account`` is the single source of truth for persisting
+    the freshly obtained tokens against the correct target media user.
+    """
+    async with TraktClient(client_id, client_secret, db=db) as client:
+        token_payload = await client.poll_for_token(device_code)
+        user_settings = await client.get_user_settings()
+    return token_payload, user_settings
+
+
+def _mark_error_unless_connected(db: DatabaseManager, provider: str, external_user_id: str, message: str) -> None:
+    """Mark a media user's Trakt link errored, unless it is already connected."""
+    try:
+        identity = db.get_media_user_identity(provider.lower(), str(external_user_id))
+    except (ValueError, KeyError):
+        return
+    link = db.get_trakt_account_link(identity["id"])
+    if link and not link["connected"]:
+        db.mark_trakt_account_link_error(identity["id"], "error", message)
+
+
+@trakt_bp.route("/media-users", methods=["GET"])
+@require_role("admin")
+def list_media_users():
+    """Admin: list media-server users with token-safe Trakt status."""
+    db = DatabaseManager()
+    provider = _selected_provider()
+    result = []
+    for user in _selected_media_users():
+        ext_id = str(user.get("id"))
+        link = {"connected": False}
+        try:
+            identity = db.get_media_user_identity(provider, ext_id)
+            existing = db.get_trakt_account_link(identity["id"])
+            if existing:
+                link = existing
+                if link.get("connected"):
+                    sources = db.get_enabled_trakt_sources(identity["id"])
+                    watched = next((s for s in sources if s["source_type"] == "watched_history"), {})
+                    link["use_as_seed"] = watched.get("use_as_seed", True)
+                    link["use_as_exclusion"] = watched.get("use_as_exclusion", True)
+        except ValueError:
+            link = {"connected": False}
+        result.append({
+            "provider": provider,
+            "external_user_id": ext_id,
+            "external_username": user.get("name"),
+            "trakt": link,
+        })
+    return jsonify({"media_users": result}), 200
+
+
+@trakt_bp.route("/media-users/<provider>/<external_user_id>/device/code", methods=["POST"])
+@require_role("admin")
+def request_media_user_device_code(provider: str, external_user_id: str):
+    """Admin: start Trakt device-code OAuth for a target media user."""
+    db = DatabaseManager()
+    if _find_selected_user(provider, external_user_id) is None:
+        return jsonify({"message": "Media user not found", "status": "error"}), 404
+
+    payload = _get_json()
+    client_id, client_secret, from_payload = _resolve_trakt_credentials(payload)
+    if not client_id or not client_secret:
+        return jsonify({"message": "Configure Trakt app credentials first", "status": "error"}), 400
+
+    _save_app_credentials_if_supplied(db, client_id, client_secret, from_payload)
+
+    try:
+        activation = async_to_sync(_request_device_code)(client_id, client_secret, db)
+        return jsonify(activation), 200
+    except RuntimeError as exc:
+        logger.warning("Trakt device-code request failed for %s/%s: %s", provider, external_user_id, exc)
+        return jsonify({"message": str(exc), "status": "error"}), 400
+    except Exception as exc:
+        logger.error("Unexpected Trakt device-code error for %s/%s: %s", provider, external_user_id, exc, exc_info=True)
+        return jsonify({"message": "Error requesting Trakt device code", "status": "error"}), 500
+
+
+@trakt_bp.route("/media-users/<provider>/<external_user_id>/device/token", methods=["POST"])
+@require_role("admin")
+def poll_media_user_device_token(provider: str, external_user_id: str):
+    """Admin: poll Trakt OAuth completion and persist tokens for a target media user."""
+    db = DatabaseManager()
+    user = _find_selected_user(provider, external_user_id)
+    if user is None:
+        return jsonify({"message": "Media user not found", "status": "error"}), 404
+
+    payload = _get_json()
+    device_code = payload.get("device_code")
+    if not device_code:
+        return jsonify({"message": "device_code is required", "status": "error"}), 400
+
+    client_id, client_secret, _ = _resolve_trakt_credentials(payload)
+    if not client_id or not client_secret:
+        return jsonify({"message": "Configure Trakt app credentials first", "status": "error"}), 400
+
+    provider = provider.lower()
+    external_user_id = str(external_user_id)
+
+    try:
+        token_payload, user_settings = async_to_sync(_poll_device_token)(
+            client_id, client_secret, str(device_code), db,
+        )
+        # 1. Upsert media user identity (the (provider, external_user_id) anchor)
+        identity = db.upsert_media_user_identity(
+            provider, external_user_id, user.get("name"),
+        )
+
+        # 2. Upsert Trakt account link (keyed by the media user identity)
+        link_id = db.upsert_trakt_account_link(
+            media_user_identity_id=identity["id"],
+            trakt_user_id=user_settings.get("trakt_user_id"),
+            trakt_username=user_settings.get("trakt_username"),
+            token_source="manual_oauth",
+            status="connected",
+        )
+
+        # 3. Upsert OAuth tokens
+        db.upsert_trakt_oauth_tokens(
+            link_id=link_id,
+            access_token=token_payload.get("access_token", ""),
+            refresh_token=token_payload.get("refresh_token", ""),
+            expires_at=token_payload.get("expires_at"),
+        )
+
+        # 4. Upsert default watched_history source
+        db.upsert_trakt_source(
+            media_user_identity_id=identity["id"],
+            source_type="watched_history",
+            source_key="watched_history",
+            enabled=True,
+            use_as_seed=True,
+            use_as_exclusion=True,
+        )
+
+        return jsonify({
+            "connected": True,
+            "status": "connected",
+            "trakt_user_id": user_settings.get("trakt_user_id"),
+            "trakt_username": user_settings.get("trakt_username"),
+            "expires_at": token_payload.get("expires_at"),
+        }), 200
+    except TraktDevicePending:
+        return jsonify({"connected": False, "status": "pending"}), 202
+    except (TraktDeviceExpired, TraktDeviceDenied) as exc:
+        _mark_error_unless_connected(db, provider, external_user_id, str(exc))
+        logger.info("Trakt device-token poll failed for %s/%s: %s", provider, external_user_id, exc)
+        return jsonify({"message": str(exc), "status": "error"}), 400
+    except RuntimeError as exc:
+        logger.info("Trakt device-token poll failed for %s/%s: %s", provider, external_user_id, exc)
+        _mark_error_unless_connected(db, provider, external_user_id, "Trakt connection failed")
+        return jsonify({"message": "Trakt connection failed", "status": "error"}), 400
+    except Exception as exc:
+        logger.error("Unexpected Trakt device-token error for %s/%s: %s", provider, external_user_id, exc, exc_info=True)
+        _mark_error_unless_connected(db, provider, external_user_id, "Trakt connection failed")
+        return jsonify({"message": "Error connecting Trakt", "status": "error"}), 500
+
+
+@trakt_bp.route("/media-users/<provider>/<external_user_id>", methods=["DELETE"])
+@require_role("admin")
+def delete_media_user_trakt_account(provider: str, external_user_id: str):
+    """Admin: unlink the Trakt account associated with a media user."""
+    db = DatabaseManager()
+    if _find_selected_user(provider, external_user_id) is None:
+        return jsonify({"message": "Media user not found", "status": "error"}), 404
+    try:
+        identity = db.get_media_user_identity(provider.lower(), str(external_user_id))
+        db.unlink_trakt_account(identity["id"])
+    except (ValueError, KeyError):
+        pass
+    return jsonify({"connected": False, "status": "deleted"}), 200
+
+
+@trakt_bp.route("/sources/<provider>/<external_user_id>", methods=["PUT"])
+@require_role("admin")
+def update_trakt_source(provider: str, external_user_id: str):
+    """Admin: toggle use_as_seed / use_as_exclusion for a media user's watched_history source."""
+    db = DatabaseManager()
+    payload = _get_json()
+
+    try:
+        identity = db.get_media_user_identity(provider.lower(), str(external_user_id))
+    except ValueError:
+        return jsonify({"message": "Media user not found", "status": "error"}), 404
+
+    sources = db.get_trakt_sources(identity["id"])
+    watched_source = None
+    for s in sources:
+        if s["source_type"] == "watched_history":
+            watched_source = s
+            break
+
+    if not watched_source:
+        return jsonify({"message": "No watched_history source found", "status": "error"}), 404
+
+    use_as_seed = payload.get("use_as_seed", watched_source["use_as_seed"])
+    use_as_exclusion = payload.get("use_as_exclusion", watched_source["use_as_exclusion"])
+
+    db.upsert_trakt_source(
+        media_user_identity_id=identity["id"],
+        source_type="watched_history",
+        source_key="watched_history",
+        enabled=watched_source["enabled"],
+        use_as_seed=bool(use_as_seed),
+        use_as_exclusion=bool(use_as_exclusion),
+        list_id=watched_source.get("list_id"),
+        list_slug=watched_source.get("list_slug"),
+        username=watched_source.get("username"),
+    )
+
+    return jsonify({
+        "use_as_seed": bool(use_as_seed),
+        "use_as_exclusion": bool(use_as_exclusion),
+    }), 200

--- a/api_service/config/config.py
+++ b/api_service/config/config.py
@@ -20,6 +20,7 @@ INTEGRATION_TO_FLAT: dict = {
                  'session_token': 'SEER_SESSION_TOKEN'},
     'omdb':     {'api_key': 'OMDB_API_KEY'},
     'openai':   {'api_key': 'OPENAI_API_KEY', 'base_url': 'OPENAI_BASE_URL', 'model': 'LLM_MODEL'},
+    'trakt':    {'client_id': 'TRAKT_CLIENT_ID', 'client_secret': 'TRAKT_CLIENT_SECRET'},
 }
 
 _CONFIG_CACHE_LOCK = threading.Lock()
@@ -214,6 +215,11 @@ def get_default_values():
         'OPENAI_API_KEY': lambda: '',
         'OPENAI_BASE_URL': lambda: '',
         'LLM_MODEL': lambda: 'gpt-4o-mini',
+        'TRAKT_CLIENT_ID': lambda: '',
+        'TRAKT_CLIENT_SECRET': lambda: '',
+        'TRAKT_ACCESS_TOKEN': lambda: '',
+        'TRAKT_REFRESH_TOKEN': lambda: '',
+        'TRAKT_EXPIRES_AT': lambda: None,
         'CACHE_TTL': lambda: 24,
         'MAX_CACHE_SIZE': lambda: 100,
         'API_TIMEOUT': lambda: 30,
@@ -318,6 +324,8 @@ def get_config_sections():
                     'PLEX_LIBRARIES', 'JELLYFIN_API_URL', 'JELLYFIN_TOKEN', 'JELLYFIN_LIBRARIES',
                     'SEER_API_URL', 'SEER_TOKEN', 'SEER_USER_NAME', 'SEER_USER_PSW',
                     'SEER_SESSION_TOKEN', 'SEER_ANIME_PROFILE_CONFIG', 'SEER_REQUEST_DELAY',
+                    'TRAKT_CLIENT_ID', 'TRAKT_CLIENT_SECRET', 'TRAKT_ACCESS_TOKEN',
+                    'TRAKT_REFRESH_TOKEN', 'TRAKT_EXPIRES_AT',
                     'SELECTED_USERS'],
         'database': ['DB_TYPE', 'DB_HOST', 'DB_PORT', 'DB_USER', 'DB_PASSWORD', 'DB_NAME',
                     'DB_MIN_CONNECTIONS', 'DB_MAX_CONNECTIONS', 'DB_MAX_IDLE_TIME', 

--- a/api_service/db/database_manager.py
+++ b/api_service/db/database_manager.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, Optional, List, Tuple, Set
 from api_service.config.config import load_env_vars
 from api_service.config.logger_manager import LoggerManager
 from api_service.exceptions.database_exceptions import DatabaseError
+from api_service.services.integration_sanitizer import sanitize_integration_config
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 DB_PATH = os.path.join(BASE_DIR, 'config', 'config_files', 'requests.db')
@@ -29,6 +30,7 @@ _INTEGRATION_REQUIRED_FIELDS: Dict[str, List[str]] = {
     'seer':     ['api_url', 'api_key'],
     'tmdb':     ['api_key'],
     'omdb':     ['api_key'],
+    'trakt':    ['client_id', 'client_secret'],
     # OpenAI/LLM: no hard required fields - either api_key (cloud) or base_url (local) is sufficient.
     # An existing row (even empty) is considered valid to prevent overwriting user configuration.
     'openai':   [],
@@ -324,6 +326,61 @@ class DatabaseManager:
                     config_json TEXT NOT NULL,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
+            """,
+            'media_user_identities': """
+                CREATE TABLE IF NOT EXISTS media_user_identities (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    provider TEXT NOT NULL,
+                    external_user_id TEXT NOT NULL,
+                    external_username TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE (provider, external_user_id)
+                )
+            """,
+            'trakt_account_links': """
+                CREATE TABLE IF NOT EXISTS trakt_account_links (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    media_user_identity_id INTEGER NOT NULL,
+                    trakt_user_id TEXT,
+                    trakt_username TEXT,
+                    token_source TEXT NOT NULL DEFAULT 'manual_oauth',
+                    status TEXT NOT NULL DEFAULT 'connected',
+                    last_synced_at TIMESTAMP,
+                    last_error TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (media_user_identity_id) REFERENCES media_user_identities(id) ON DELETE CASCADE,
+                    UNIQUE (media_user_identity_id)
+                )
+            """,
+            'trakt_oauth_tokens': """
+                CREATE TABLE IF NOT EXISTS trakt_oauth_tokens (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    link_id INTEGER NOT NULL UNIQUE,
+                    access_token TEXT NOT NULL,
+                    refresh_token TEXT NOT NULL,
+                    expires_at BIGINT,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (link_id) REFERENCES trakt_account_links(id) ON DELETE CASCADE
+                )
+            """,
+            'trakt_sources': """
+                CREATE TABLE IF NOT EXISTS trakt_sources (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    media_user_identity_id INTEGER NOT NULL,
+                    source_type TEXT NOT NULL,
+                    source_key TEXT NOT NULL,
+                    list_id TEXT,
+                    list_slug TEXT,
+                    username TEXT,
+                    enabled INTEGER NOT NULL DEFAULT 1,
+                    use_as_seed INTEGER NOT NULL DEFAULT 1,
+                    use_as_exclusion INTEGER NOT NULL DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (media_user_identity_id) REFERENCES media_user_identities(id) ON DELETE CASCADE,
+                    UNIQUE (media_user_identity_id, source_type, source_key)
+                )
             """
         }
         
@@ -333,59 +390,11 @@ class DatabaseManager:
                 with self.get_connection() as conn:
                     cursor = conn.cursor()
                     
-                    # Database-specific modifications
-                    if self.db_type in ['mysql', 'mariadb']:
-                        # Keep full VARCHAR storage but constrain indexed prefixes to stay
-                        # under InnoDB's key-length limit when using utf8mb4.
-                        if table_name == 'requests':
-                            query = query.replace(
-                                "UNIQUE(media_type, tmdb_request_id, tmdb_source_id),",
-                                "UNIQUE KEY uniq_requests_identity (media_type(191), tmdb_request_id(191), tmdb_source_id(191)),"
-                            )
-                        elif table_name == 'metadata':
-                            query = query.replace(
-                                "UNIQUE(media_id, media_type)",
-                                "UNIQUE KEY uniq_metadata_media_type (media_id(191), media_type(191))"
-                            )
-                        elif table_name == 'pending_requests':
-                            query = query.replace(
-                                "UNIQUE(tmdb_id, media_type)",
-                                "UNIQUE KEY uniq_pending_tmdb_media_type (tmdb_id(191), media_type(191))"
-                            )
-                        elif table_name == 'ai_search_seen':
-                            query = """
-                                CREATE TABLE IF NOT EXISTS ai_search_seen (
-                                    tmdb_id VARCHAR(64) NOT NULL,
-                                    media_type VARCHAR(16) NOT NULL,
-                                    last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                                    PRIMARY KEY (tmdb_id, media_type)
-                                ) ENGINE=InnoDB
-                            """
-                        elif table_name == 'ai_search_feedback':
-                            query = """
-                                CREATE TABLE IF NOT EXISTS ai_search_feedback (
-                                    tmdb_id VARCHAR(64) NOT NULL,
-                                    media_type VARCHAR(16) NOT NULL,
-                                    feedback VARCHAR(16) NOT NULL,
-                                    title VARCHAR(512),
-                                    year INTEGER,
-                                    rationale VARCHAR(512),
-                                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                                    PRIMARY KEY (tmdb_id, media_type)
-                                ) ENGINE=InnoDB
-                            """
-
-                        # Order matters: do specific replacements first
-                        query = query.replace("INTEGER PRIMARY KEY AUTOINCREMENT", "INT AUTO_INCREMENT PRIMARY KEY")
-                        query = query.replace("INTEGER", "INT")
-                        query = query.replace("TEXT", "VARCHAR(512)")
-                        query = query.replace("REAL", "DOUBLE")
-                        # Add ENGINE=InnoDB for foreign key support
-                        if not query.strip().endswith("ENGINE=InnoDB"):
-                            query = query.rstrip().rstrip(")").rstrip() + ") ENGINE=InnoDB"
-                    elif self.db_type == 'postgres':
-                        query = query.replace("INTEGER PRIMARY KEY AUTOINCREMENT", "SERIAL PRIMARY KEY")
-                        query = query.replace("AUTOINCREMENT", "")
+                    query = self._prepare_create_table_query_for_db(
+                        table_name,
+                        query,
+                        self.db_type,
+                    )
 
                     self.logger.info(f"Creating table '{table_name}'...")
                     cursor.execute(query)
@@ -404,11 +413,92 @@ class DatabaseManager:
                     db_type=self.db_type
                 )
         
+        if self.db_type in ('mysql', 'mariadb'):
+            try:
+                corrections = [
+                    ("ALTER TABLE trakt_account_links MODIFY media_user_identity_id INTEGER NOT NULL", ()),
+                    ("ALTER TABLE trakt_account_links MODIFY token_source TEXT NOT NULL", ()),
+                    ("ALTER TABLE trakt_account_links MODIFY last_error TEXT", ()),
+                    ("ALTER TABLE trakt_oauth_tokens MODIFY access_token TEXT NOT NULL", ()),
+                    ("ALTER TABLE trakt_oauth_tokens MODIFY refresh_token TEXT NOT NULL", ()),
+                    ("ALTER TABLE trakt_sources MODIFY media_user_identity_id INTEGER NOT NULL", ()),
+                ]
+                with self.get_connection() as conn:
+                    cursor = conn.cursor()
+                    for stmt, params in corrections:
+                        cursor.execute(stmt, params)
+                    conn.commit()
+                self.logger.debug("Applied MySQL column type corrections for new tables")
+            except Exception as e:
+                self.logger.error(f"Failed to apply MySQL column corrections: {e}")
+                raise DatabaseError(
+                    error=f"MySQL column correction failed: {str(e)}",
+                    db_type=self.db_type
+                )
+
         # Add missing columns
         self.add_missing_columns()
 
         # Create submission lock table (separate to control column types per DB engine)
         self._create_submission_locks_table()
+
+    def _prepare_create_table_query_for_db(self, table_name: str, query: str, db_type: str) -> str:
+        """Apply database-specific DDL rewrites for a table creation query."""
+        if db_type in ['mysql', 'mariadb']:
+            # Keep full VARCHAR storage but constrain indexed prefixes to stay
+            # under InnoDB's key-length limit when using utf8mb4.
+            if table_name == 'requests':
+                query = query.replace(
+                    "UNIQUE(media_type, tmdb_request_id, tmdb_source_id),",
+                    "UNIQUE KEY uniq_requests_identity (media_type(191), tmdb_request_id(191), tmdb_source_id(191)),"
+                )
+            elif table_name == 'metadata':
+                query = query.replace(
+                    "UNIQUE(media_id, media_type)",
+                    "UNIQUE KEY uniq_metadata_media_type (media_id(191), media_type(191))"
+                )
+            elif table_name == 'pending_requests':
+                query = query.replace(
+                    "UNIQUE(tmdb_id, media_type)",
+                    "UNIQUE KEY uniq_pending_tmdb_media_type (tmdb_id(191), media_type(191))"
+                )
+            elif table_name == 'ai_search_seen':
+                query = """
+                    CREATE TABLE IF NOT EXISTS ai_search_seen (
+                        tmdb_id VARCHAR(64) NOT NULL,
+                        media_type VARCHAR(16) NOT NULL,
+                        last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (tmdb_id, media_type)
+                    ) ENGINE=InnoDB
+                """
+            elif table_name == 'ai_search_feedback':
+                query = """
+                    CREATE TABLE IF NOT EXISTS ai_search_feedback (
+                        tmdb_id VARCHAR(64) NOT NULL,
+                        media_type VARCHAR(16) NOT NULL,
+                        feedback VARCHAR(16) NOT NULL,
+                        title VARCHAR(512),
+                        year INTEGER,
+                        rationale VARCHAR(512),
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (tmdb_id, media_type)
+                    ) ENGINE=InnoDB
+                """
+
+            # Order matters: do specific replacements first.
+            query = query.replace("INTEGER PRIMARY KEY AUTOINCREMENT", "INT AUTO_INCREMENT PRIMARY KEY")
+            query = query.replace("INTEGER", "INT")
+            query = query.replace("TEXT", "VARCHAR(512)")
+            query = query.replace("REAL", "DOUBLE")
+
+            # Add ENGINE=InnoDB for foreign key support.
+            if not query.strip().endswith("ENGINE=InnoDB"):
+                query = query.rstrip().rstrip(")").rstrip() + ") ENGINE=InnoDB"
+        elif db_type == 'postgres':
+            query = query.replace("INTEGER PRIMARY KEY AUTOINCREMENT", "SERIAL PRIMARY KEY")
+            query = query.replace("AUTOINCREMENT", "")
+
+        return query
 
     def _create_submission_locks_table(self):
         """Create the submission_locks table for cross-process submission deduplication."""
@@ -692,7 +782,7 @@ class DatabaseManager:
             row = cursor.fetchone()
         if row is None:
             return None
-        return json.loads(row[0])
+        return self._sanitize_integration_config(service, json.loads(row[0]))
 
     def get_all_integrations(self) -> dict:
         """
@@ -706,7 +796,10 @@ class DatabaseManager:
             cursor = conn.cursor()
             cursor.execute(query)
             rows = cursor.fetchall()
-        return {row[0]: json.loads(row[1]) for row in rows}
+        return {
+            row[0]: self._sanitize_integration_config(row[0], json.loads(row[1]))
+            for row in rows
+        }
 
     def set_integration(self, service: str, config: dict) -> None:
         """
@@ -716,6 +809,7 @@ class DatabaseManager:
             service: Integration service name.
             config: Configuration dict to persist as JSON.
         """
+        config = self._sanitize_integration_config(service, config)
         config_json = json.dumps(config)
         now = datetime.now(timezone.utc)
 
@@ -762,6 +856,17 @@ class DatabaseManager:
         required = _INTEGRATION_REQUIRED_FIELDS.get(service, [])
         return all(config.get(field) for field in required)
 
+    @staticmethod
+    def _sanitize_integration_config(service: str, config: dict) -> dict:
+        """Return an integration config safe for generic integrations storage.
+
+        Thin delegator to the shared public helper
+        :func:`api_service.services.integration_sanitizer.sanitize_integration_config`
+        so the allow-listing logic lives in a single place. Retained as a
+        backward-compatible alias for existing call sites/tests.
+        """
+        return sanitize_integration_config(service, config)
+
     def migrate_integrations_from_config(self) -> None:
         """
         Startup migration: seed or repair the integrations table from config.yaml.
@@ -790,6 +895,10 @@ class DatabaseManager:
             'omdb': {
                 'api_key': env_vars.get('OMDB_API_KEY', ''),
             },
+            'trakt': {
+                'client_id': env_vars.get('TRAKT_CLIENT_ID', ''),
+                'client_secret': env_vars.get('TRAKT_CLIENT_SECRET', ''),
+            },
         }
 
         # AI provider: only seed the DB when YAML already has a key or base_url configured.
@@ -805,6 +914,9 @@ class DatabaseManager:
 
         for service, config in candidates.items():
             existing = self.get_integration(service)
+
+            if service == 'trakt' and existing is not None:
+                self.set_integration(service, existing)
 
             if existing is not None and self._is_integration_valid(service, existing):
                 self.logger.debug(
@@ -822,7 +934,9 @@ class DatabaseManager:
                 continue
 
             action = "Updating" if existing is not None else "Migrating"
-            safe_log = {k: v for k, v in config.items() if k not in ('api_key', 'session_token')}
+            safe_log = {k: v for k, v in config.items() if k not in (
+                'api_key', 'session_token', 'client_secret', 'access_token', 'refresh_token'
+            )}
             self.logger.info(
                 "%s '%s' credentials from config.yaml -> integrations table %s",
                 action, service, safe_log,
@@ -2418,6 +2532,403 @@ class DatabaseManager:
     # ---------------------------------------------------------------------------
     # User media profile methods
     # ---------------------------------------------------------------------------
+
+    @staticmethod
+    def _coerce_trakt_expires_at(expires_at: Any) -> Any:
+        """Normalize datetime expiry values while leaving epoch values intact."""
+        if isinstance(expires_at, datetime):
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            return int(expires_at.astimezone(timezone.utc).timestamp())
+        return expires_at
+
+    # ---- media_user_identities ------------------------------------------------
+    # A media-server user is identified by (provider, external_user_id); the
+    # identity row is the anchor that Trakt account links and sources hang off.
+
+    def upsert_media_user_identity(
+        self, provider: str, external_user_id: str, external_username: Optional[str] = None
+    ) -> Dict[str, Any]:
+        ph = self._ph()
+        provider = str(provider).lower()
+        external_user_id = str(external_user_id)
+        if self.db_type == 'sqlite':
+            query = (
+                f"INSERT INTO media_user_identities (provider, external_user_id, external_username) "
+                f"VALUES ({ph}, {ph}, {ph}) "
+                f"ON CONFLICT(provider, external_user_id) DO UPDATE SET "
+                f"external_username = COALESCE(excluded.external_username, media_user_identities.external_username)"
+            )
+        elif self.db_type == 'postgres':
+            query = (
+                f"INSERT INTO media_user_identities (provider, external_user_id, external_username) "
+                f"VALUES ({ph}, {ph}, {ph}) "
+                f"ON CONFLICT (provider, external_user_id) DO UPDATE SET "
+                f"external_username = COALESCE(EXCLUDED.external_username, media_user_identities.external_username)"
+            )
+        else:
+            query = (
+                f"INSERT INTO media_user_identities (provider, external_user_id, external_username) "
+                f"VALUES ({ph}, {ph}, {ph}) "
+                f"ON DUPLICATE KEY UPDATE "
+                f"external_username = COALESCE(VALUES(external_username), external_username)"
+            )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (provider, external_user_id, external_username))
+            conn.commit()
+        return self.get_media_user_identity(provider, external_user_id)
+
+    def get_media_user_identity(self, provider: str, external_user_id: str) -> Dict[str, Any]:
+        ph = self._ph()
+        query = (
+            f"SELECT id, provider, external_user_id, external_username, created_at "
+            f"FROM media_user_identities WHERE provider = {ph} AND external_user_id = {ph}"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (provider.lower(), str(external_user_id)))
+            row = cursor.fetchone()
+        if row is None:
+            raise ValueError(f"Media user identity not found: {provider}/{external_user_id}")
+        return {"id": row[0], "provider": row[1], "external_user_id": row[2],
+                "external_username": row[3], "created_at": row[4]}
+
+    def get_media_user_identity_by_id(self, identity_id: int) -> Optional[Dict[str, Any]]:
+        ph = self._ph()
+        query = (
+            f"SELECT id, provider, external_user_id, external_username, created_at "
+            f"FROM media_user_identities WHERE id = {ph}"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (identity_id,))
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return {"id": row[0], "provider": row[1], "external_user_id": row[2],
+                "external_username": row[3], "created_at": row[4]}
+
+    # ---- trakt_account_links --------------------------------------------------
+
+    def upsert_trakt_account_link(
+        self,
+        media_user_identity_id: int,
+        trakt_user_id: Optional[str],
+        trakt_username: Optional[str],
+        token_source: str = "manual_oauth",
+        status: str = "connected",
+    ) -> int:
+        ph = self._ph()
+        columns = (
+            "(media_user_identity_id, trakt_user_id, trakt_username, token_source, "
+            "status, updated_at)"
+        )
+        values = f"({ph}, {ph}, {ph}, {ph}, {ph}, CURRENT_TIMESTAMP)"
+        if self.db_type == 'sqlite':
+            query = (
+                f"INSERT INTO trakt_account_links {columns} VALUES {values} "
+                f"ON CONFLICT(media_user_identity_id) DO UPDATE SET "
+                f"trakt_user_id = excluded.trakt_user_id, "
+                f"trakt_username = excluded.trakt_username, "
+                f"token_source = excluded.token_source, "
+                f"status = excluded.status, "
+                f"last_error = NULL, "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        elif self.db_type == 'postgres':
+            query = (
+                f"INSERT INTO trakt_account_links {columns} VALUES {values} "
+                f"ON CONFLICT (media_user_identity_id) DO UPDATE SET "
+                f"trakt_user_id = EXCLUDED.trakt_user_id, "
+                f"trakt_username = EXCLUDED.trakt_username, "
+                f"token_source = EXCLUDED.token_source, "
+                f"status = EXCLUDED.status, "
+                f"last_error = NULL, "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        else:
+            query = (
+                f"INSERT INTO trakt_account_links {columns} VALUES {values} "
+                f"ON DUPLICATE KEY UPDATE "
+                f"trakt_user_id = VALUES(trakt_user_id), "
+                f"trakt_username = VALUES(trakt_username), "
+                f"token_source = VALUES(token_source), "
+                f"status = VALUES(status), "
+                f"last_error = NULL, "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (
+                media_user_identity_id, trakt_user_id, trakt_username, token_source, status,
+            ))
+            conn.commit()
+            # Re-SELECT the id rather than trusting cursor.lastrowid: on the
+            # ON CONFLICT DO UPDATE (re-link) path no row is inserted, so
+            # lastrowid is 0 on a fresh SQLite connection, which would break the
+            # foreign-keyed token upsert that follows.
+            cursor.execute(
+                f"SELECT id FROM trakt_account_links WHERE media_user_identity_id = {ph}",
+                (media_user_identity_id,),
+            )
+            return cursor.fetchone()[0]
+
+    def _row_to_trakt_link(self, row) -> Dict[str, Any]:
+        status = row[5] or "connected"
+        return {
+            "id": row[0], "media_user_identity_id": row[1], "trakt_user_id": row[2],
+            "trakt_username": row[3], "token_source": row[4], "status": status,
+            "last_synced_at": row[6], "last_error": row[7],
+            "created_at": row[8], "updated_at": row[9],
+            "connected": status == "connected",
+        }
+
+    _TRAKT_LINK_COLUMNS = (
+        "id, media_user_identity_id, trakt_user_id, trakt_username, token_source, "
+        "status, last_synced_at, last_error, created_at, updated_at"
+    )
+
+    def get_trakt_account_link(self, media_user_identity_id: int) -> Optional[Dict[str, Any]]:
+        ph = self._ph()
+        query = (
+            f"SELECT {self._TRAKT_LINK_COLUMNS} FROM trakt_account_links "
+            f"WHERE media_user_identity_id = {ph}"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (media_user_identity_id,))
+            row = cursor.fetchone()
+        return self._row_to_trakt_link(row) if row else None
+
+    def get_trakt_account_link_by_id(self, link_id: int) -> Optional[Dict[str, Any]]:
+        ph = self._ph()
+        query = f"SELECT {self._TRAKT_LINK_COLUMNS} FROM trakt_account_links WHERE id = {ph}"
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (link_id,))
+            row = cursor.fetchone()
+        return self._row_to_trakt_link(row) if row else None
+
+    def mark_trakt_account_link_error(
+        self, media_user_identity_id: int, status: str, last_error: Optional[str]
+    ) -> bool:
+        ph = self._ph()
+        query = (
+            f"UPDATE trakt_account_links SET status = {ph}, last_error = {ph}, "
+            f"updated_at = CURRENT_TIMESTAMP WHERE media_user_identity_id = {ph}"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (status, last_error, media_user_identity_id))
+            updated = cursor.rowcount
+            conn.commit()
+        return updated > 0
+
+    def unlink_trakt_account(self, media_user_identity_id: int) -> bool:
+        ph = self._ph()
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            # Explicitly remove dependent OAuth tokens first. The FK declares
+            # ON DELETE CASCADE, but we do not rely on runtime FK enforcement
+            # (PRAGMA foreign_keys) being on, so clean up the child rows here.
+            cursor.execute(
+                f"DELETE FROM trakt_oauth_tokens WHERE link_id IN "
+                f"(SELECT id FROM trakt_account_links WHERE media_user_identity_id = {ph})",
+                (media_user_identity_id,),
+            )
+            cursor.execute(
+                f"DELETE FROM trakt_account_links WHERE media_user_identity_id = {ph}",
+                (media_user_identity_id,),
+            )
+            deleted = cursor.rowcount
+            conn.commit()
+        return deleted > 0
+
+    def get_all_trakt_account_link_statuses(self) -> List[Dict[str, Any]]:
+        query = f"SELECT {self._TRAKT_LINK_COLUMNS} FROM trakt_account_links"
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query)
+            rows = cursor.fetchall()
+        return [self._row_to_trakt_link(row) for row in rows]
+
+    # ---- trakt_oauth_tokens ---------------------------------------------------
+
+    def upsert_trakt_oauth_tokens(
+        self, link_id: int, access_token: str, refresh_token: str, expires_at: Any
+    ) -> None:
+        ph = self._ph()
+        expires_at = self._coerce_trakt_expires_at(expires_at)
+        columns = "(link_id, access_token, refresh_token, expires_at, updated_at)"
+        values = f"({ph}, {ph}, {ph}, {ph}, CURRENT_TIMESTAMP)"
+        if self.db_type == 'sqlite':
+            query = (
+                f"INSERT INTO trakt_oauth_tokens {columns} VALUES {values} "
+                f"ON CONFLICT(link_id) DO UPDATE SET "
+                f"access_token = excluded.access_token, "
+                f"refresh_token = excluded.refresh_token, "
+                f"expires_at = excluded.expires_at, "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        elif self.db_type == 'postgres':
+            query = (
+                f"INSERT INTO trakt_oauth_tokens {columns} VALUES {values} "
+                f"ON CONFLICT (link_id) DO UPDATE SET "
+                f"access_token = EXCLUDED.access_token, "
+                f"refresh_token = EXCLUDED.refresh_token, "
+                f"expires_at = EXCLUDED.expires_at, "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        else:
+            query = (
+                f"INSERT INTO trakt_oauth_tokens {columns} VALUES {values} "
+                f"ON DUPLICATE KEY UPDATE "
+                f"access_token = VALUES(access_token), "
+                f"refresh_token = VALUES(refresh_token), "
+                f"expires_at = VALUES(expires_at), "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (link_id, access_token, refresh_token, expires_at))
+            conn.commit()
+
+    def get_trakt_oauth_tokens(self, link_id: int) -> Optional[Dict[str, Any]]:
+        ph = self._ph()
+        query = (
+            f"SELECT access_token, refresh_token, expires_at "
+            f"FROM trakt_oauth_tokens WHERE link_id = {ph}"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (link_id,))
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return {"access_token": row[0], "refresh_token": row[1], "expires_at": row[2]}
+
+    def update_trakt_oauth_tokens(
+        self, link_id: int, access_token: str, refresh_token: str, expires_at: Any
+    ) -> bool:
+        ph = self._ph()
+        expires_at = self._coerce_trakt_expires_at(expires_at)
+        query = (
+            f"UPDATE trakt_oauth_tokens SET access_token = {ph}, refresh_token = {ph}, "
+            f"expires_at = {ph}, updated_at = CURRENT_TIMESTAMP WHERE link_id = {ph}"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (access_token, refresh_token, expires_at, link_id))
+            updated = cursor.rowcount
+            conn.commit()
+        return updated > 0
+
+    def delete_trakt_oauth_tokens(self, link_id: int) -> bool:
+        ph = self._ph()
+        query = f"DELETE FROM trakt_oauth_tokens WHERE link_id = {ph}"
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (link_id,))
+            deleted = cursor.rowcount
+            conn.commit()
+        return deleted > 0
+
+    # ---- trakt_sources --------------------------------------------------------
+
+    def upsert_trakt_source(
+        self,
+        media_user_identity_id: int,
+        source_type: str,
+        source_key: str,
+        enabled: bool = True,
+        use_as_seed: bool = True,
+        use_as_exclusion: bool = True,
+        **kwargs,
+    ) -> None:
+        ph = self._ph()
+        list_id = kwargs.get("list_id")
+        list_slug = kwargs.get("list_slug")
+        username = kwargs.get("username")
+        columns = (
+            "(media_user_identity_id, source_type, source_key, list_id, list_slug, username, "
+            "enabled, use_as_seed, use_as_exclusion, updated_at)"
+        )
+        values = f"({ph}, {ph}, {ph}, {ph}, {ph}, {ph}, {ph}, {ph}, {ph}, CURRENT_TIMESTAMP)"
+        if self.db_type == 'sqlite':
+            query = (
+                f"INSERT INTO trakt_sources {columns} VALUES {values} "
+                f"ON CONFLICT(media_user_identity_id, source_type, source_key) DO UPDATE SET "
+                f"list_id = excluded.list_id, list_slug = excluded.list_slug, "
+                f"username = excluded.username, enabled = excluded.enabled, "
+                f"use_as_seed = excluded.use_as_seed, "
+                f"use_as_exclusion = excluded.use_as_exclusion, "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        elif self.db_type == 'postgres':
+            query = (
+                f"INSERT INTO trakt_sources {columns} VALUES {values} "
+                f"ON CONFLICT (media_user_identity_id, source_type, source_key) DO UPDATE SET "
+                f"list_id = EXCLUDED.list_id, list_slug = EXCLUDED.list_slug, "
+                f"username = EXCLUDED.username, enabled = EXCLUDED.enabled, "
+                f"use_as_seed = EXCLUDED.use_as_seed, "
+                f"use_as_exclusion = EXCLUDED.use_as_exclusion, "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        else:
+            query = (
+                f"INSERT INTO trakt_sources {columns} VALUES {values} "
+                f"ON DUPLICATE KEY UPDATE "
+                f"list_id = VALUES(list_id), list_slug = VALUES(list_slug), "
+                f"username = VALUES(username), enabled = VALUES(enabled), "
+                f"use_as_seed = VALUES(use_as_seed), "
+                f"use_as_exclusion = VALUES(use_as_exclusion), "
+                f"updated_at = CURRENT_TIMESTAMP"
+            )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (
+                media_user_identity_id, source_type, source_key, list_id, list_slug, username,
+                int(enabled), int(use_as_seed), int(use_as_exclusion),
+            ))
+            conn.commit()
+
+    def _row_to_trakt_source(self, r) -> Dict[str, Any]:
+        return {
+            "id": r[0], "media_user_identity_id": r[1], "source_type": r[2], "source_key": r[3],
+            "list_id": r[4], "list_slug": r[5], "username": r[6],
+            "enabled": bool(r[7]), "use_as_seed": bool(r[8]), "use_as_exclusion": bool(r[9]),
+            "created_at": r[10], "updated_at": r[11],
+        }
+
+    _TRAKT_SOURCE_COLUMNS = (
+        "id, media_user_identity_id, source_type, source_key, list_id, list_slug, "
+        "username, enabled, use_as_seed, use_as_exclusion, created_at, updated_at"
+    )
+
+    def get_trakt_sources(self, media_user_identity_id: int) -> List[Dict[str, Any]]:
+        ph = self._ph()
+        query = (
+            f"SELECT {self._TRAKT_SOURCE_COLUMNS} FROM trakt_sources "
+            f"WHERE media_user_identity_id = {ph}"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (media_user_identity_id,))
+            rows = cursor.fetchall()
+        return [self._row_to_trakt_source(r) for r in rows]
+
+    def get_enabled_trakt_sources(self, media_user_identity_id: int) -> List[Dict[str, Any]]:
+        ph = self._ph()
+        query = (
+            f"SELECT {self._TRAKT_SOURCE_COLUMNS} FROM trakt_sources "
+            f"WHERE media_user_identity_id = {ph} AND enabled = 1"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, (media_user_identity_id,))
+            rows = cursor.fetchall()
+        return [self._row_to_trakt_source(r) for r in rows]
 
     def create_user_media_profile(
         self,

--- a/api_service/handler/base_handler.py
+++ b/api_service/handler/base_handler.py
@@ -27,7 +27,8 @@ class BaseMediaHandler(ABC):
     def __init__(self, seer_client, tmdb_client, logger,
                  max_similar_movie, max_similar_tv, library_anime_map=None,
                  use_llm=None, request_delay=0, honor_seer_discovery=False,
-                 seer_discovered_ids=None, dry_run=False, max_total_requests=None):
+                 seer_discovered_ids=None, dry_run=False, max_total_requests=None,
+                 trakt_augmentor=None, max_content=10):
         """
         Initialize base media handler.
         
@@ -44,12 +45,16 @@ class BaseMediaHandler(ABC):
             seer_discovered_ids: Set of already discovered item IDs
             dry_run: Whether to simulate requests
             max_total_requests: Maximum requestable items for the whole run
+            trakt_augmentor: Optional MediaUserTraktAugmentor used to add Trakt
+                watch-history seeds and merge fully-watched IDs into the skip set
+            max_content: Max seeds to process after merging server + Trakt sources
         """
         self.seer_client = seer_client
         self.tmdb_client = tmdb_client
         self.logger = logger
         self.max_similar_movie = max_similar_movie
         self.max_similar_tv = max_similar_tv
+        self.max_content = int(max_content) if max_content else 10
         self.request_count = 0
         
         # Optimization: Pre-process existing_content into sets for O(1) lookups
@@ -68,6 +73,7 @@ class BaseMediaHandler(ABC):
         self.max_total_requests = int(max_total_requests) if max_total_requests else None
         self._request_slots_reserved = 0
         self._request_limit_lock = asyncio.Lock()
+        self.trakt_augmentor = trakt_augmentor
         
         # Determine LLM mode
         if use_llm is not None:
@@ -108,7 +114,67 @@ class BaseMediaHandler(ABC):
 
         async with self._request_limit_lock:
             self._request_slots_reserved = max(self._request_slots_reserved - 1, 0)
-    
+
+    async def _augment_user_trakt(self, media_user_identity_id):
+        """Fetch a media user's Trakt watch history additively.
+
+        Merges fully-watched Trakt TMDB IDs into ``existing_content_sets`` (so
+        they are skipped like already-owned content) and returns a list of
+        normalized Trakt seed dicts (each with ``tmdb_id``, ``media_type``,
+        ``title``, ``year``) for the caller to process. A missing augmentor,
+        missing link, or any Trakt failure is a silent no-op returning ``[]``.
+        """
+        augmentor = getattr(self, "trakt_augmentor", None)
+        if not augmentor or not media_user_identity_id:
+            return []
+
+        augmentation = await augmentor.augment(media_user_identity_id)
+        if augmentation is None:
+            return []
+
+        total_watched = sum(len(v) for v in augmentation.watched_ids.values())
+        self.logger.info(
+            "Trakt: media user identity %s → %d seeds, %d watched IDs",
+            media_user_identity_id, len(augmentation.seed_items), total_watched,
+        )
+
+        # Skip-watched merge: Trakt fully-watched titles join existing content.
+        for media_type in ("movie", "tv"):
+            watched = augmentation.watched_ids.get(media_type)
+            if watched:
+                self.existing_content_sets.setdefault(media_type, set()).update(watched)
+
+        return list(augmentation.seed_items)
+
+    def _merge_seeds(self, seeds):
+        """Merge server and Trakt seeds, sort by date, dedup, cap to max_content.
+
+        Each seed dict must have: ``tmdb_id``, ``media_type``, ``date`` (Unix
+        timestamp). Seeds without ``date`` sort last.  Duplicate
+        ``(media_type, tmdb_id)`` pairs keep the newest entry (first seen in
+        descending sort).
+
+        Returns the merged list truncated to ``self.max_content`` items.
+        """
+        if not seeds:
+            return []
+
+        seen = set()
+        deduped = []
+        for s in sorted(seeds, key=lambda x: x.get("date", 0), reverse=True):
+            key = (s.get("media_type"), str(s.get("tmdb_id", "")))
+            if key in seen or not s.get("tmdb_id"):
+                continue
+            seen.add(key)
+            deduped.append(s)
+
+        if len(deduped) > self.max_content:
+            self.logger.info(
+                "Merged seeds capped from %d to %d (max_content)",
+                len(deduped), self.max_content,
+            )
+        return deduped[:self.max_content]
+
     @abstractmethod
     def _populate_existing_content_sets(self):
         """

--- a/api_service/handler/jellyfin_handler.py
+++ b/api_service/handler/jellyfin_handler.py
@@ -2,9 +2,10 @@ import asyncio
 
 from api_service.handler.base_handler import BaseMediaHandler
 from api_service.services.jellyfin.jellyfin_client import JellyfinClient
+from api_service.db.database_manager import DatabaseManager
 
 class JellyfinHandler(BaseMediaHandler):
-    def __init__(self, jellyfin_client:JellyfinClient, seer_client, tmdb_client, logger, max_similar_movie, max_similar_tv, selected_users, library_anime_map=None, use_llm=None, request_delay=0, honor_seer_discovery=False, seer_discovered_ids=None, dry_run=False, max_total_requests=None):
+    def __init__(self, jellyfin_client:JellyfinClient, seer_client, tmdb_client, logger, max_similar_movie, max_similar_tv, selected_users, library_anime_map=None, use_llm=None, request_delay=0, honor_seer_discovery=False, seer_discovered_ids=None, dry_run=False, max_total_requests=None, trakt_augmentor=None, max_content=10):
         """
         Initialize JellyfinHandler with clients and parameters.
         :param jellyfin_client: Jellyfin API client
@@ -19,6 +20,7 @@ class JellyfinHandler(BaseMediaHandler):
         :param request_delay: Seconds to wait between consecutive Seer service requests (0 = concurrent).
         :param dry_run: If True, simulate requests without touching download clients.
         :param max_total_requests: Max number of items to request for the whole run.
+        :param max_content: Max seeds to process after merging Trakt + Jellyfin sources.
         """
         super().__init__(
             seer_client=seer_client,
@@ -32,7 +34,9 @@ class JellyfinHandler(BaseMediaHandler):
             honor_seer_discovery=honor_seer_discovery,
             seer_discovered_ids=seer_discovered_ids,
             dry_run=dry_run,
-            max_total_requests=max_total_requests
+            max_total_requests=max_total_requests,
+            trakt_augmentor=trakt_augmentor,
+            max_content=max_content,
         )
         self.jellyfin_client = jellyfin_client
         self.selected_users = selected_users
@@ -58,59 +62,155 @@ class JellyfinHandler(BaseMediaHandler):
         self.logger.info(f"Total media requested: {self.request_count}")
 
     async def process_user_recent_items(self, user):
-        """Process recently watched items for a specific Jellyfin user."""
+        """Process recently watched items for a Jellyfin user, merged with Trakt."""
         if not isinstance(user, dict):
             self.logger.error(f"Invalid user object (not a dict): {user}")
             return
         user_name = user.get('name', user.get('id', 'Unknown'))
         self.logger.info(f"Fetching content for user: {user_name}")
+
+        # 1. Collect Trakt seeds (don't process yet).
+        trakt_seeds = await self._collect_trakt_seeds_for_user(user)
+
+        # 2. Fetch Jellyfin recent items.
         recent_items_by_library = await self.jellyfin_client.get_recent_items(user)
         self.logger.debug(f"Recent items for user {user['name']}: {recent_items_by_library}")
 
+        jf_seeds = []
         if recent_items_by_library:
+            # Flatten all items across libraries and resolve TMDB IDs in parallel.
+            flat_items = []
+            for library_name, items in recent_items_by_library.items():
+                is_anime = self.library_anime_map.get(library_name, False)
+                for item in items:
+                    flat_items.append((item, library_name, is_anime))
+
+            jf_seeds = await asyncio.gather(*[
+                self._jellyfin_item_to_seed(item, library_name, is_anime, user)
+                for item, library_name, is_anime in flat_items
+            ])
+            jf_seeds = [s for s in jf_seeds if s is not None]
+
+        # 3. Merge Trakt + Jellyfin seeds, sort by date, dedup, cap.
+        all_seeds = trakt_seeds + jf_seeds
+        merged = self._merge_seeds(all_seeds)
+        if not merged:
+            return
+
+        self.logger.info("Processing %d merged seeds for Jellyfin user %s", len(merged), user_name)
+        await self._process_merged_seeds(user, merged)
+
+    async def _jellyfin_item_to_seed(self, item, library_name, is_anime, user):
+        """Resolve a Jellyfin item to a normalized seed dict or None."""
+        item_type = item.get('Type', '').lower()
+        media_type = 'movie' if item_type == 'movie' else 'tv'
+        title = item.get('SeriesName') if item_type == 'episode' else item.get('Name')
+        if not title:
+            return None
+
+        # Resolve TMDB ID.
+        tmdb_id = None
+        if media_type == 'movie':
+            tmdb_id = (item.get('ProviderIds') or {}).get('Tmdb')
+        else:
+            tmdb_id = ((item.get('SeriesProviderIds') or item.get('ProviderIds', {})).get('Tmdb'))
+            if not tmdb_id:
+                series_id = item.get('SeriesId')
+                if series_id:
+                    try:
+                        series_pids = await self.jellyfin_client.get_series_provider_ids(series_id)
+                        tmdb_id = (series_pids or {}).get('Tmdb')
+                    except Exception:
+                        pass
+        if not tmdb_id:
+            return None
+
+        # Parse date.
+        date = 0
+        for field in ('DatePlayed', 'DateCreated', 'PremiereDate'):
+            val = item.get(field)
+            if val:
+                try:
+                    from datetime import datetime as dt
+                    date = int(dt.fromisoformat(str(val).replace('Z', '+00:00')).timestamp())
+                except (ValueError, TypeError):
+                    pass
+                break
+
+        source_obj = None
+        try:
+            source_obj = await self.tmdb_client.get_metadata(tmdb_id, media_type)
+        except (AttributeError, Exception):
+            pass
+        return {
+            'tmdb_id': str(tmdb_id), 'media_type': media_type,
+            'title': title, 'year': item.get('ProductionYear'),
+            'date': date, 'source_obj': source_obj, 'is_anime': is_anime,
+            'user': user,
+        }
+
+    async def _collect_trakt_seeds_for_user(self, user):
+        """Fetch Trakt seeds for a user, return list without processing."""
+        if not self.trakt_augmentor:
+            return []
+
+        external_id = str(user.get('id'))
+        identity = DatabaseManager().upsert_media_user_identity(
+            provider="jellyfin", external_user_id=external_id, external_username=user.get('name'),
+        )
+        seeds = await self._augment_user_trakt(identity["id"])
+        for s in seeds:
+            s.setdefault('date', s.get('watched_at', 0))
+        return seeds
+
+    async def _process_merged_seeds(self, user, seeds):
+        """Process merged seeds for a Jellyfin user: dispatch LLM or non-LLM."""
+        if not seeds:
+            return
+
+        if self.use_llm:
+            movie_history = [
+                {"title": s["title"], "year": s.get("year"), "type": "movie"}
+                for s in seeds if s.get("media_type") == "movie"
+            ]
+            tv_history = [
+                {"title": s["title"], "year": s.get("year"), "type": "tv"}
+                for s in seeds if s.get("media_type") == "tv"
+            ]
             tasks = []
-            if self.use_llm:
-                self.logger.info("Advanced Algorithm enabled. Generating recommendations using LLM.")
-                # We extract all recently watched items across libraries for the LLM
-                all_recent_items = []
-                for library_name, items in recent_items_by_library.items():
-                    all_recent_items.extend(items)
-                
-                history_items = []
-                for item in all_recent_items:
-                    item_type_raw = item.get('Type', '').lower()
-                    if item_type_raw == 'episode':
-                        # Use the series name, not the individual episode title
-                        title = item.get('SeriesName') or item.get('Name')
-                        media_type = 'tv'
-                    else:
-                        title = item.get('Name')
-                        media_type = 'movie'
-                    year = item.get('ProductionYear')
-                    if title:
-                        history_items.append({
-                            "title": title,
-                            "year": year,
-                            "type": media_type,
-                        })
-                
-                if history_items:
-                    # Filter history list for movies vs tv to feed to LLM
-                    movie_history = [h for h in history_items if h['type'] == 'movie']
-                    tv_history = [h for h in history_items if h['type'] == 'tv']
-                    
-                    if movie_history:
-                        tasks.append(self.process_llm_recommendations(user, movie_history, 'movie', self.max_similar_movie))
-                    if tv_history:
-                        tasks.append(self.process_llm_recommendations(user, tv_history, 'tv', self.max_similar_tv))
-            else:
-                for library_name, items in recent_items_by_library.items():
-                    is_anime = self.library_anime_map.get(library_name, False)
-                    self.logger.debug(f"Processing library: {library_name} (anime={is_anime}) with items: {items}")
-                    tasks.extend([self.process_item(user, item, is_anime) for item in items])
-                    
+            if movie_history and self.max_similar_movie > 0:
+                tasks.append(self.process_llm_recommendations(user, movie_history, 'movie', self.max_similar_movie))
+            if tv_history and self.max_similar_tv > 0:
+                tasks.append(self.process_llm_recommendations(user, tv_history, 'tv', self.max_similar_tv))
             if tasks:
                 await asyncio.gather(*tasks)
+        else:
+            await asyncio.gather(*[
+                self._process_seed(user, seed) for seed in seeds
+            ])
+
+    async def _process_seed(self, user, seed):
+        """Find similar media for one TMDB-resolved seed and request via Seer."""
+        tmdb_id = seed.get("tmdb_id")
+        media_type = seed.get("media_type")
+        if not tmdb_id:
+            return
+        source_obj = seed.get("source_obj")
+        is_anime = seed.get("is_anime", False)
+        if media_type == "movie" and self.max_similar_movie > 0:
+            if not source_obj:
+                source_obj = await self.tmdb_client.get_metadata(tmdb_id, "movie")
+            if not source_obj:
+                return
+            similar = await self.tmdb_client.find_similar_movies(tmdb_id, dry_run=self.dry_run)
+            await self.request_similar_media(similar, "movie", self.max_similar_movie, source_obj, user, is_anime)
+        elif media_type == "tv" and self.max_similar_tv > 0:
+            if not source_obj:
+                source_obj = await self.tmdb_client.get_metadata(tmdb_id, "tv")
+            if not source_obj:
+                return
+            similar = await self.tmdb_client.find_similar_tvshows(tmdb_id, dry_run=self.dry_run)
+            await self.request_similar_media(similar, "tv", self.max_similar_tv, source_obj, user, is_anime)
 
     async def _request_llm_recommendation(self, media, item_type, source_obj, user):
         """Request a single LLM recommendation via Jellyfin."""

--- a/api_service/handler/plex_handler.py
+++ b/api_service/handler/plex_handler.py
@@ -3,6 +3,7 @@ import unicodedata
 
 from api_service.handler.base_handler import BaseMediaHandler
 from api_service.services.plex.plex_client import PlexClient, normalize_guid_provider_id
+from api_service.db.database_manager import DatabaseManager
 
 def to_ascii(value):
     """
@@ -15,7 +16,7 @@ def to_ascii(value):
     return unicodedata.normalize('NFKD', value)
 
 class PlexHandler(BaseMediaHandler):
-    def __init__(self, plex_client: PlexClient, seer_client, tmdb_client, logger, max_similar_movie, max_similar_tv, library_anime_map=None, use_llm=None, request_delay=0, honor_seer_discovery=False, seer_discovered_ids=None, dry_run=False, max_total_requests=None):
+    def __init__(self, plex_client: PlexClient, seer_client, tmdb_client, logger, max_similar_movie, max_similar_tv, library_anime_map=None, use_llm=None, request_delay=0, honor_seer_discovery=False, seer_discovered_ids=None, dry_run=False, max_total_requests=None, trakt_augmentor=None, selected_users=None, max_content=10):
         """
         Initialize PlexHandler with clients and parameters.
         :param plex_client: Plex API client
@@ -29,6 +30,7 @@ class PlexHandler(BaseMediaHandler):
         :param request_delay: Seconds to wait between consecutive Seer service requests (0 = concurrent).
         :param dry_run: If True, simulate requests without touching download clients.
         :param max_total_requests: Max number of items to request for the whole run.
+        :param max_content: Max seeds to process after merging Trakt + Plex sources.
         """
         super().__init__(
             seer_client=seer_client,
@@ -42,9 +44,12 @@ class PlexHandler(BaseMediaHandler):
             honor_seer_discovery=honor_seer_discovery,
             seer_discovered_ids=seer_discovered_ids,
             dry_run=dry_run,
-            max_total_requests=max_total_requests
+            max_total_requests=max_total_requests,
+            trakt_augmentor=trakt_augmentor,
+            max_content=max_content,
         )
         self.plex_client = plex_client
+        self.selected_users = selected_users or []
         self._populate_existing_content_sets()
     
     def _populate_existing_content_sets(self):
@@ -63,64 +68,153 @@ class PlexHandler(BaseMediaHandler):
 
 
     async def process_recent_items(self):
-        """Process recently watched items for Plex (without user context)."""
+        """Process recently watched items for Plex, merged with Trakt seeds."""
+        # 1. Collect Trakt seeds (doesn't process them yet).
+        trakt_seeds = await self._collect_trakt_seeds()
+
+        # 2. Fetch Plex recent items and resolve their TMDB IDs.
         self.logger.info("Fetching recently watched content from Plex")
         recent_items_response = await self.plex_client.get_recent_items()
 
-        if isinstance(recent_items_response, list):
-            for response_item in recent_items_response:
-                title = response_item.get('title', response_item.get('grandparentTitle'))
-                if title is not None and isinstance(title, str):
-                    title = to_ascii(title)
-                # Look up anime status from the item's library section ID
-                library_section_id = str(response_item.get('librarySectionID', ''))
-                is_anime = self.library_anime_map.get(library_section_id, False)
-                self.logger.info(f"Processing item: {title} (anime={is_anime})")
-
-            if recent_items_response:
-                if self.use_llm:
-                    self.logger.info("Advanced Algorithm enabled. Generating recommendations using LLM.")
-                    movie_history, tv_history = [], []
-                    for response_item in recent_items_response:
-                        item_type_raw = response_item.get('type', '').lower()
-                        if item_type_raw == 'episode':
-                            title = response_item.get('grandparentTitle')
-                            media_type = 'tv'
-                        else:
-                            title = response_item.get('title')
-                            media_type = 'movie'
-                        year = response_item.get('year')
-                        if title:
-                            entry = {"title": title, "year": year}
-                            if media_type == 'movie':
-                                movie_history.append(entry)
-                            else:
-                                tv_history.append(entry)
-
-                    llm_tasks = []
-                    if movie_history and self.max_similar_movie > 0:
-                        llm_tasks.append(self.process_llm_recommendations(movie_history, 'movie', self.max_similar_movie))
-                    if tv_history and self.max_similar_tv > 0:
-                        llm_tasks.append(self.process_llm_recommendations(tv_history, 'tv', self.max_similar_tv))
-                    if llm_tasks:
-                        await asyncio.gather(*llm_tasks)
-                else:
-                    tasks = []
-                    for response_item in recent_items_response:
-                        title = response_item.get('title', response_item.get('grandparentTitle'))
-                        if title is not None and isinstance(title, str):
-                            title = to_ascii(title)
-                        library_section_id = str(response_item.get('librarySectionID', ''))
-                        is_anime = self.library_anime_map.get(library_section_id, False)
-                        tasks.append(self.process_item(response_item, title, is_anime))
-                    if tasks:
-                        await asyncio.gather(*tasks)
-                
-                self.logger.info(f"Total media requested: {self.request_count}")
+        if not isinstance(recent_items_response, list) or not recent_items_response:
+            if trakt_seeds:
+                trakt_seeds = self._merge_seeds(trakt_seeds)
+                await self._process_merged_seeds(trakt_seeds)
             else:
                 self.logger.warning("No recent items found in Plex response")
+            return
+
+        # Resolve all Plex items to seed dicts in parallel.
+        plex_seeds = await asyncio.gather(*[
+            self._plex_item_to_seed(item) for item in recent_items_response
+        ])
+        plex_seeds = [s for s in plex_seeds if s is not None]
+
+        # 3. Merge Trakt + Plex seeds, sort by date, dedup, cap.
+        all_seeds = trakt_seeds + plex_seeds
+        merged = self._merge_seeds(all_seeds)
+        if not merged:
+            return
+
+        self.logger.info("Processing %d merged seeds (Trakt + Plex)", len(merged))
+        await self._process_merged_seeds(merged)
+
+    async def _plex_item_to_seed(self, item):
+        """Resolve a Plex response item to a normalized seed dict or None."""
+        item_type = item.get('type', '').lower()
+        title = item.get('grandparentTitle') if item_type == 'episode' else item.get('title')
+        if not title:
+            return None
+
+        key = item.get('key') if item_type == 'movie' else item.get('grandparentKey')
+        if not key:
+            return None
+
+        try:
+            tmdb_id = await self.plex_client.get_metadata_provider_id(key)
+        except Exception:
+            self.logger.warning("Failed to resolve TMDB ID for Plex item '%s'", title)
+            return None
+        if not tmdb_id:
+            return None
+
+        media_type = 'movie' if item_type == 'movie' else 'tv'
+        library_section_id = str(item.get('librarySectionID', ''))
+        is_anime = self.library_anime_map.get(library_section_id, False)
+
+        # Parse date: prefer viewedAt, fall back to addedAt, then 0.
+        date = 0
+        for field in ('viewedAt', 'addedAt', 'updatedAt', 'originallyAvailableAt'):
+            val = item.get(field)
+            if val:
+                try:
+                    from datetime import datetime as dt
+                    date = int(dt.fromisoformat(str(val).replace('Z', '+00:00')).timestamp())
+                except (ValueError, TypeError):
+                    pass
+                break
+
+        source_obj = None
+        try:
+            source_obj = await self.tmdb_client.get_metadata(tmdb_id, media_type)
+        except (AttributeError, Exception):
+            pass
+        return {
+            'tmdb_id': str(tmdb_id), 'media_type': media_type,
+            'title': title, 'year': item.get('year'),
+            'date': date, 'source_obj': source_obj, 'is_anime': is_anime,
+        }
+
+    async def _collect_trakt_seeds(self):
+        """Fetch Trakt seeds for all linked users, return list without processing."""
+        if not self.trakt_augmentor or not self.selected_users:
+            return []
+
+        db = DatabaseManager()
+        all_seeds = []
+        for media_user in self.selected_users:
+            external_id = str(media_user.get('id')) if isinstance(media_user, dict) else str(media_user)
+            external_username = media_user.get('name') if isinstance(media_user, dict) else None
+            identity = db.upsert_media_user_identity(
+                provider="plex", external_user_id=external_id, external_username=external_username,
+            )
+            seeds = await self._augment_user_trakt(identity["id"])
+            if seeds:
+                all_seeds.extend(seeds)
+
+        for s in all_seeds:
+            s.setdefault('date', s.get('watched_at', 0))
+
+        return all_seeds
+
+    async def _process_merged_seeds(self, seeds):
+        """Process merged seeds: dispatch to LLM or non-LLM path."""
+        if not seeds:
+            return
+
+        if self.use_llm:
+            movie_history = [
+                {"title": s["title"], "year": s.get("year"), "type": "movie"}
+                for s in seeds if s.get("media_type") == "movie"
+            ]
+            tv_history = [
+                {"title": s["title"], "year": s.get("year"), "type": "tv"}
+                for s in seeds if s.get("media_type") == "tv"
+            ]
+            tasks = []
+            if movie_history and self.max_similar_movie > 0:
+                tasks.append(self.process_llm_recommendations(movie_history, 'movie', self.max_similar_movie))
+            if tv_history and self.max_similar_tv > 0:
+                tasks.append(self.process_llm_recommendations(tv_history, 'tv', self.max_similar_tv))
+            if tasks:
+                await asyncio.gather(*tasks)
         else:
-            self.logger.warning("Unexpected response format: expected a list")
+            await asyncio.gather(*[
+                self._process_seed(seed) for seed in seeds
+            ])
+
+    async def _process_seed(self, seed):
+        """Find similar media for one TMDB-resolved seed and request via Seer."""
+        tmdb_id = seed.get("tmdb_id")
+        media_type = seed.get("media_type")
+        if not tmdb_id:
+            return
+        source_obj = seed.get("source_obj")
+        is_anime = seed.get("is_anime", False)
+        if media_type == "movie" and self.max_similar_movie > 0:
+            if not source_obj:
+                source_obj = await self.tmdb_client.get_metadata(tmdb_id, "movie")
+            if not source_obj:
+                return
+            similar = await self.tmdb_client.find_similar_movies(tmdb_id, dry_run=self.dry_run)
+            await self.request_similar_media(similar, "movie", self.max_similar_movie, source_obj, is_anime)
+        elif media_type == "tv" and self.max_similar_tv > 0:
+            if not source_obj:
+                source_obj = await self.tmdb_client.get_metadata(tmdb_id, "tv")
+            if not source_obj:
+                return
+            similar = await self.tmdb_client.find_similar_tvshows(tmdb_id, dry_run=self.dry_run)
+            await self.request_similar_media(similar, "tv", self.max_similar_tv, source_obj, is_anime)
 
     async def _request_llm_recommendation(self, media, item_type, source_obj):
         """Request a single LLM recommendation via Plex."""

--- a/api_service/jobs/recommendation_automation.py
+++ b/api_service/jobs/recommendation_automation.py
@@ -12,6 +12,7 @@ from api_service.db.database_manager import DatabaseManager
 from api_service.db.job_repository import JobRepository
 from api_service.handler.jellyfin_handler import JellyfinHandler
 from api_service.handler.plex_handler import PlexHandler
+from api_service.services.trakt.media_user_augmentor import MediaUserTraktAugmentor
 from api_service.services.filter_normalization import normalize_filters
 from api_service.services.jellyfin.jellyfin_client import JellyfinClient
 from api_service.services.seer.seer_client import SeerClient
@@ -239,6 +240,14 @@ class RecommendationAutomation:
         honor_seer_discovery = _resolve_honor_seer_discovery(job_filters, self.env_vars)
         seer_discovered_ids = self._get_seer_discovered_tmdb_ids() if honor_seer_discovery else set()
 
+        # Trakt seed / exclusion flags — job overrides env, default True
+        _resolve_bool = lambda key, env_key, default=True: (
+            bool(job_filters[key]) if key in job_filters
+            else bool(self.env_vars.get(env_key, default))
+        )
+        trakt_use_as_seed = _resolve_bool('use_trakt_as_seed', 'TRAKT_USE_AS_SEED')
+        trakt_use_as_exclusion = _resolve_bool('use_trakt_as_exclusion', 'TRAKT_USE_AS_EXCLUSION')
+
         # Language filter
         filter_language = []
         if normalized_filters.get('language'):
@@ -369,7 +378,9 @@ class RecommendationAutomation:
                 max_total_requests=max_results,
                 honor_seer_discovery=honor_seer_discovery,
                 seer_discovered_ids=seer_discovered_ids,
-                dry_run=dry_run
+                dry_run=dry_run,
+                trakt_use_as_seed=trakt_use_as_seed,
+                trakt_use_as_exclusion=trakt_use_as_exclusion,
             )
         elif selected_service == 'plex':
             await self._init_plex_handler(
@@ -378,7 +389,9 @@ class RecommendationAutomation:
                 max_total_requests=max_results,
                 honor_seer_discovery=honor_seer_discovery,
                 seer_discovered_ids=seer_discovered_ids,
-                dry_run=dry_run
+                dry_run=dry_run,
+                trakt_use_as_seed=trakt_use_as_seed,
+                trakt_use_as_exclusion=trakt_use_as_exclusion,
             )
         else:
             raise ValueError(f"Unsupported service: {selected_service}")
@@ -420,7 +433,9 @@ class RecommendationAutomation:
         max_total_requests=None,
         honor_seer_discovery: bool = False,
         seer_discovered_ids: Optional[set[str]] = None,
-        dry_run=False
+        dry_run=False,
+        trakt_use_as_seed=True,
+        trakt_use_as_exclusion=True,
     ):
         """Initialize Jellyfin handler."""
         self.logger.info("Initializing Jellyfin client")
@@ -449,7 +464,13 @@ class RecommendationAutomation:
             honor_seer_discovery=honor_seer_discovery,
             seer_discovered_ids=seer_discovered_ids,
             dry_run=dry_run,
-            max_total_requests=max_total_requests
+            max_total_requests=max_total_requests,
+            trakt_augmentor=MediaUserTraktAugmentor.from_env(
+                self.env_vars, max_content,
+                use_as_seed=trakt_use_as_seed,
+                use_as_exclusion=trakt_use_as_exclusion,
+            ),
+            max_content=max_content,
         )
         self.logger.info("Jellyfin handler initialized")
 
@@ -459,7 +480,9 @@ class RecommendationAutomation:
         max_total_requests=None,
         honor_seer_discovery: bool = False,
         seer_discovered_ids: Optional[set[str]] = None,
-        dry_run=False
+        dry_run=False,
+        trakt_use_as_seed=True,
+        trakt_use_as_exclusion=True,
     ):
         """Initialize Plex handler."""
         self.logger.info("Initializing Plex client")
@@ -489,7 +512,14 @@ class RecommendationAutomation:
             honor_seer_discovery=honor_seer_discovery,
             seer_discovered_ids=seer_discovered_ids,
             dry_run=dry_run,
-            max_total_requests=max_total_requests
+            max_total_requests=max_total_requests,
+            trakt_augmentor=MediaUserTraktAugmentor.from_env(
+                self.env_vars, max_content,
+                use_as_seed=trakt_use_as_seed,
+                use_as_exclusion=trakt_use_as_exclusion,
+            ),
+            selected_users=selected_users,
+            max_content=max_content,
         )
         self.logger.info("Plex handler initialized")
 

--- a/api_service/jobs/system_job_sync.py
+++ b/api_service/jobs/system_job_sync.py
@@ -206,6 +206,15 @@ def _build_filters_from_config(env_vars: Dict[str, Any]) -> Dict[str, Any]:
     if exclude_requested is not None:
         filters['exclude_requested'] = bool(exclude_requested)
 
+    # Trakt seed / exclusion flags
+    trakt_use_as_seed = env_vars.get('TRAKT_USE_AS_SEED')
+    if trakt_use_as_seed is not None:
+        filters['use_trakt_as_seed'] = bool(trakt_use_as_seed)
+
+    trakt_use_as_exclusion = env_vars.get('TRAKT_USE_AS_EXCLUSION')
+    if trakt_use_as_exclusion is not None:
+        filters['use_trakt_as_exclusion'] = bool(trakt_use_as_exclusion)
+
     return filters
 
 

--- a/api_service/services/ai_search/ai_search_service.py
+++ b/api_service/services/ai_search/ai_search_service.py
@@ -7,6 +7,7 @@ import asyncio
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+
 from api_service.config.logger_manager import LoggerManager
 from api_service.services.config_service import ConfigService
 from api_service.services.filter_normalization import build_tmdb_params, normalize_filters

--- a/api_service/services/config_service.py
+++ b/api_service/services/config_service.py
@@ -12,6 +12,7 @@ from api_service.config.config import (
 )
 from api_service.config.logger_manager import LoggerManager
 from api_service.db.database_manager import DatabaseManager
+from api_service.services.integration_sanitizer import sanitize_integration_config
 
 logger = LoggerManager.get_logger(__name__)
 
@@ -32,10 +33,46 @@ _DB_INTEGRATION_KEYS: frozenset = frozenset({
     'OPENAI_API_KEY',
     'OPENAI_BASE_URL',
     'LLM_MODEL',
+    'TRAKT_CLIENT_ID',
+    'TRAKT_CLIENT_SECRET',
+})
+
+_TRAKT_ACCOUNT_TOKEN_SETTING_KEYS: frozenset = frozenset({
+    'TRAKT_ACCESS_TOKEN',
+    'TRAKT_REFRESH_TOKEN',
+    'TRAKT_EXPIRES_AT',
 })
 
 # All valid top-level setting keys (resolved once at module load).
-_VALID_SETTING_KEYS: frozenset = frozenset(get_default_values().keys()) - _DB_INTEGRATION_KEYS
+_VALID_SETTING_KEYS: frozenset = (
+    frozenset(get_default_values().keys())
+    - _DB_INTEGRATION_KEYS
+    - _TRAKT_ACCOUNT_TOKEN_SETTING_KEYS
+)
+
+_LOG_SECRET_KEY_FRAGMENTS: tuple = ("token", "api_key", "password", "secret")
+
+
+def _sanitize_integration_config(service: str, config: dict) -> dict:
+    """Return a copy of an integration config safe for global storage/export.
+
+    Thin wrapper delegating to the canonical public helper
+    :func:`api_service.services.integration_sanitizer.sanitize_integration_config`
+    so the Trakt-allowlist logic lives in a single place.
+    """
+    return sanitize_integration_config(service, config)
+
+
+def _redact_for_log(config: dict) -> dict:
+    """Return a copy with secret-like keys redacted for logging."""
+    safe = {}
+    for key, value in config.items():
+        key_lower = str(key).lower()
+        if any(fragment in key_lower for fragment in _LOG_SECRET_KEY_FRAGMENTS):
+            safe[key] = "***"
+        else:
+            safe[key] = value
+    return safe
 
 
 class ConfigService:
@@ -64,7 +101,10 @@ class ConfigService:
             dict with keys ``version``, ``integrations``, ``settings``.
         """
         db = DatabaseManager()
-        integrations = db.get_all_integrations()
+        integrations = {
+            service: _sanitize_integration_config(service, cfg)
+            for service, cfg in db.get_all_integrations().items()
+        }
         logger.info(
             "Config export: collected %d integration(s): %s",
             len(integrations),
@@ -75,7 +115,7 @@ class ConfigService:
         settings = {
             k: v
             for k, v in config.items()
-            if k not in _DB_INTEGRATION_KEYS
+            if k in _VALID_SETTING_KEYS
         }
 
         return {
@@ -120,8 +160,9 @@ class ConfigService:
                     "Skipping integration '%s': value is not a dict", service
                 )
                 continue
+            service_cfg = _sanitize_integration_config(service, service_cfg)
             # Log non-sensitive fields only.
-            safe = {k: v for k, v in service_cfg.items() if k not in ("api_key", "session_token")}
+            safe = _redact_for_log(service_cfg)
             logger.info("Importing integration '%s' %s", service, safe)
             db.set_integration(service, service_cfg)
 

--- a/api_service/services/integration_sanitizer.py
+++ b/api_service/services/integration_sanitizer.py
@@ -1,0 +1,30 @@
+"""Shared helpers for sanitizing integration configuration payloads.
+
+This module hosts the canonical implementation used both by the database layer
+(:class:`api_service.db.database_manager.DatabaseManager`) and the config
+export/import service (:mod:`api_service.services.config_service`) so the
+per-service allow-listing logic lives in a single, public place.
+"""
+
+from typing import Any, Dict
+
+
+def sanitize_integration_config(service: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return an integration config safe for generic integrations storage/export.
+
+    For most services the config is passed through verbatim (a shallow copy).
+    The ``trakt`` service is allow-listed to only the app-level OAuth credential
+    keys so per-user OAuth tokens never leak into the shared integrations store
+    or exported snapshots.
+
+    :param service: Integration service name (e.g. ``'trakt'``, ``'jellyfin'``).
+    :param config: Raw integration config dict.
+    :return: A new dict containing only the keys that are safe to persist/export.
+    """
+    if service != 'trakt':
+        return dict(config)
+    return {
+        key: value
+        for key, value in config.items()
+        if key in {'client_id', 'client_secret'}
+    }

--- a/api_service/services/trakt/__init__.py
+++ b/api_service/services/trakt/__init__.py
@@ -1,0 +1,1 @@
+"""Trakt service client package."""

--- a/api_service/services/trakt/media_user_augmentor.py
+++ b/api_service/services/trakt/media_user_augmentor.py
@@ -1,0 +1,204 @@
+"""Shared Trakt services: resolver, watch-history source, augmentor.
+
+Used by the media-server handlers (Plex, Jellyfin) to additively enrich
+recommendations with each linked user's Trakt watch history.
+All failures are isolated per profile.
+"""
+from dataclasses import dataclass, field
+from typing import Optional
+
+from api_service.config.logger_manager import LoggerManager
+from api_service.db.database_manager import DatabaseManager
+from api_service.services.trakt.trakt_client import TraktClient
+
+_SKIP_STATUSES = {"revoked", "error"}
+
+
+@dataclass
+class TraktAugmentation:
+    """Result of augmenting one media user with Trakt history."""
+    seed_items: list = field(default_factory=list)
+    watched_ids: dict = field(default_factory=lambda: {"movie": set(), "tv": set()})
+
+
+class TraktAccountResolver:
+    """Resolve a media user's Trakt link + tokens, keyed by media_user_identity_id (the (provider, external_user_id) anchor)."""
+
+    def __init__(self, db: Optional[DatabaseManager] = None):
+        self.db = db or DatabaseManager()
+
+    def resolve(self, media_user_identity_id: int) -> Optional[dict]:
+        """Return link metadata + tokens for a profile, or None.
+
+        Returns None when no link exists, status is revoked/error, or
+        no tokens are available (future plugin sources).
+        """
+        link = self.db.get_trakt_account_link(media_user_identity_id)
+        if not link or not link["connected"]:
+            return None
+        if str(link.get("status") or "").lower() in _SKIP_STATUSES:
+            return None
+
+        result = dict(link)
+        if link.get("token_source") == "manual_oauth":
+            tokens = self.db.get_trakt_oauth_tokens(link["id"])
+            if tokens:
+                result["access_token"] = tokens["access_token"]
+                result["refresh_token"] = tokens["refresh_token"]
+                result["expires_at"] = tokens["expires_at"]
+        # Future: plugin sources fetch token externally
+        return result if result.get("access_token") else None
+
+
+class TraktWatchHistorySource:
+    """Fetch watched history from a media user's linked Trakt account."""
+
+    def __init__(
+        self, client_id: str, client_secret: str,
+        db: Optional[DatabaseManager] = None,
+        logger=None, max_content: int = 10,
+        use_as_seed: Optional[bool] = None,
+        use_as_exclusion: Optional[bool] = None,
+    ):
+        self.client_id = (client_id or "").strip()
+        self.client_secret = (client_secret or "").strip()
+        self.db = db or DatabaseManager()
+        self.logger = logger or LoggerManager.get_logger("TraktWatchHistorySource")
+        self.max_content = max_content
+        self.resolver = TraktAccountResolver(self.db)
+        self._use_as_seed_override = use_as_seed
+        self._use_as_exclusion_override = use_as_exclusion
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.client_id and self.client_secret)
+
+    async def get_recent_items(self, media_user_identity_id: int) -> list:
+        """Return normalized recent-watched items for a profile."""
+        if not self.enabled:
+            return []
+        resolved = self.resolver.resolve(media_user_identity_id)
+        if not resolved:
+            return []
+        use_as_seed = self._use_as_seed_override
+        if use_as_seed is None:
+            source = self._get_watched_history_source(media_user_identity_id)
+            use_as_seed = source.get("use_as_seed", True) if source else None
+        if not use_as_seed:
+            return []
+        try:
+            async with TraktClient(
+                self.client_id, self.client_secret,
+                access_token=resolved.get("access_token", ""),
+                refresh_token=resolved.get("refresh_token", ""),
+                expires_at=resolved.get("expires_at"),
+                db=self.db,
+                link_id=resolved["id"],
+                token_source=resolved.get("token_source", "manual_oauth"),
+            ) as client:
+                return await client.get_recent_items(self.max_content) or []
+        except Exception as exc:
+            self.logger.warning("Trakt recent items failed for media user %s: %s", media_user_identity_id, exc)
+            return []
+
+    async def get_watched_ids(self, media_user_identity_id: int) -> dict:
+        """Return {movie: set(), tv: set()} of watched TMDB IDs."""
+        if not self.enabled:
+            return {"movie": set(), "tv": set()}
+        resolved = self.resolver.resolve(media_user_identity_id)
+        if not resolved:
+            return {"movie": set(), "tv": set()}
+        use_as_exclusion = self._use_as_exclusion_override
+        if use_as_exclusion is None:
+            source = self._get_watched_history_source(media_user_identity_id)
+            use_as_exclusion = source.get("use_as_exclusion", True) if source else None
+        if not use_as_exclusion:
+            return {"movie": set(), "tv": set()}
+        try:
+            async with TraktClient(
+                self.client_id, self.client_secret,
+                access_token=resolved.get("access_token", ""),
+                refresh_token=resolved.get("refresh_token", ""),
+                expires_at=resolved.get("expires_at"),
+                db=self.db,
+                link_id=resolved["id"],
+                token_source=resolved.get("token_source", "manual_oauth"),
+            ) as client:
+                await client.init_existing_content()
+                watched = client.existing_content or {}
+            return {
+                "movie": {str(i["tmdb_id"]) for i in watched.get("movie", []) if i.get("tmdb_id")},
+                "tv": {str(i["tmdb_id"]) for i in watched.get("tv", []) if i.get("tmdb_id")},
+            }
+        except Exception as exc:
+            self.logger.warning("Trakt watched IDs failed for media user %s: %s", media_user_identity_id, exc)
+            return {"movie": set(), "tv": set()}
+
+    def _get_watched_history_source(self, media_user_identity_id: int) -> Optional[dict]:
+        """Find the enabled watched_history trakt_source row for a profile."""
+        sources = self.db.get_enabled_trakt_sources(media_user_identity_id)
+        for s in sources:
+            if s["source_type"] == "watched_history":
+                return s
+        return None
+
+
+class MediaUserTraktAugmentor:
+    """Thin wrapper: augment a media user with Trakt seeds + watched skip IDs.
+
+    Delegates to TraktWatchHistorySource. Isolates failures (silent no-op on error).
+    """
+
+    def __init__(self, client_id: str, client_secret: str, db=None, logger=None, max_content: int = 10,
+                 use_as_seed: Optional[bool] = None, use_as_exclusion: Optional[bool] = None):
+        self.db = db or DatabaseManager()
+        self.source = TraktWatchHistorySource(
+            client_id, client_secret, db=self.db, logger=logger, max_content=max_content,
+            use_as_seed=use_as_seed, use_as_exclusion=use_as_exclusion,
+        )
+        self.logger = logger or LoggerManager.get_logger("TraktAugmentor")
+
+    @classmethod
+    def from_env(cls, env_vars: dict, max_content: int = 10,
+                 use_as_seed: Optional[bool] = None,
+                 use_as_exclusion: Optional[bool] = None):
+        """Build an augmentor from app-level Trakt credentials.
+
+        Reads ``TRAKT_CLIENT_ID``/``TRAKT_CLIENT_SECRET`` (falling back to the
+        ``integrations.trakt`` config block). Returns ``None`` when no usable
+        credentials are configured.
+
+        ``use_as_seed``/``use_as_exclusion`` override the per-user Trakt
+        source settings when set (e.g. from a job filter). When ``None`` the
+        per-user DB settings are used.
+        """
+        env_vars = env_vars if isinstance(env_vars, dict) else {}
+        integrations = env_vars.get('integrations') if isinstance(env_vars.get('integrations'), dict) else {}
+        trakt_cfg = integrations.get('trakt') if isinstance(integrations.get('trakt'), dict) else {}
+        client_id = env_vars.get('TRAKT_CLIENT_ID') or trakt_cfg.get('client_id') or ''
+        client_secret = env_vars.get('TRAKT_CLIENT_SECRET') or trakt_cfg.get('client_secret') or ''
+        augmentor = cls(str(client_id).strip(), str(client_secret).strip(), max_content=max_content,
+                        use_as_seed=use_as_seed, use_as_exclusion=use_as_exclusion)
+        return augmentor if augmentor.enabled else None
+
+    @property
+    def enabled(self) -> bool:
+        return self.source.enabled
+
+    async def augment(self, media_user_identity_id: int) -> Optional[TraktAugmentation]:
+        """Fetch recent seeds + full watched IDs for a profile."""
+        if not self.enabled:
+            return None
+        try:
+            seeds = await self.source.get_recent_items(media_user_identity_id)
+            watched_ids = await self.source.get_watched_ids(media_user_identity_id)
+            if not seeds and not any(watched_ids.values()):
+                return None
+            return TraktAugmentation(seed_items=seeds or [], watched_ids=watched_ids)
+        except Exception as exc:
+            self.logger.warning("Trakt augmentation failed for media user %s: %s", media_user_identity_id, exc)
+            try:
+                self.db.mark_trakt_account_link_error(media_user_identity_id, "error", str(exc))
+            except Exception:
+                pass
+            return None

--- a/api_service/services/trakt/trakt_client.py
+++ b/api_service/services/trakt/trakt_client.py
@@ -1,0 +1,352 @@
+import asyncio
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import aiohttp
+
+from api_service.db.database_manager import DatabaseManager
+from api_service.services.http.base_client import BaseHTTPClient
+
+
+class TraktDeviceFlowError(RuntimeError):
+    """Base error for the Trakt device-code OAuth flow."""
+
+
+class TraktDevicePending(TraktDeviceFlowError):
+    """Device authorization is still pending (covers HTTP 400 and 429 slow_down)."""
+
+
+class TraktDeviceExpired(TraktDeviceFlowError):
+    """The Trakt device code has expired (HTTP 410)."""
+
+
+class TraktDeviceDenied(TraktDeviceFlowError):
+    """The user denied the Trakt authorization (HTTP 418/409)."""
+
+
+class TraktClient(BaseHTTPClient):
+    """Async client for Trakt OAuth and watched-history APIs."""
+
+    BASE_URL = "https://api.trakt.tv"
+    REFRESH_WINDOW_SECONDS = 300
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        access_token: str = "",
+        refresh_token: str = "",
+        expires_at: Optional[int] = None,
+        session=None,
+        db=None,
+        link_id: Optional[int] = None,
+        token_source: str = "manual_oauth",
+    ):
+        super().__init__()
+        self.client_id = (client_id or "").strip()
+        self.client_secret = (client_secret or "").strip()
+        self.access_token = access_token or ""
+        self.refresh_token = refresh_token or ""
+        self.expires_at = int(expires_at or 0)
+        self.session = session
+        self._owns_session = session is None
+        self.db = db or DatabaseManager()
+        self.link_id = link_id
+        self.token_source = token_source
+        self.existing_content = {"movie": [], "tv": []}
+
+    async def _get_session(self):
+        if self.session is not None and not getattr(self.session, "closed", False):
+            return self.session
+        return await super()._get_session()
+
+    async def close(self):
+        if self._owns_session:
+            await super().close()
+
+    def _headers(self, authenticated: bool = True) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+            "trakt-api-key": self.client_id,
+            "trakt-api-version": "2",
+        }
+        if authenticated and self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+        return headers
+
+    async def request_device_code(self) -> dict[str, Any]:
+        return await self._request(
+            "POST",
+            "/oauth/device/code",
+            json={"client_id": self.client_id},
+            authenticated=False,
+        )
+
+    async def poll_for_token(self, device_code: str) -> dict[str, Any]:
+        """
+        Poll the Trakt device-token endpoint and map its status to the flow state.
+
+        Trakt signals device-flow state via HTTP status codes with mostly empty
+        bodies, so this method bypasses the generic ``_request`` error path and
+        translates each status into a dedicated outcome.
+
+        Args:
+            device_code: The device code returned by ``request_device_code``.
+
+        Returns:
+            dict[str, Any]: The persisted token payload on success.
+
+        Raises:
+            TraktDevicePending: Authorization still pending (HTTP 400/429).
+            TraktDeviceExpired: The device code expired (HTTP 410).
+            TraktDeviceDenied: The user denied authorization (HTTP 418/409).
+            TraktDeviceFlowError: Any other unexpected status code.
+            RuntimeError: Network-level failures from aiohttp.
+        """
+        url = f"{self.BASE_URL}/oauth/device/token"
+        session = await self._get_session()
+        body = {
+            "code": device_code,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+        try:
+            async with session.post(
+                url,
+                headers=self._headers(authenticated=False),
+                json=body,
+            ) as response:
+                status = response.status
+                if status in self.HTTP_OK:
+                    payload = await response.json()
+                    return self._apply_and_persist_tokens(payload)
+                if status in (400, 429):
+                    raise TraktDevicePending("Trakt device authorization pending")
+                if status == 410:
+                    raise TraktDeviceExpired("Trakt device code expired")
+                if status in (418, 409):
+                    raise TraktDeviceDenied("Trakt authorization was denied")
+                raise TraktDeviceFlowError(f"Trakt device authorization failed (status {status})")
+        except aiohttp.ClientError as exc:
+            raise RuntimeError(f"Trakt API request failed: POST {url}: {exc}") from exc
+
+    async def refresh_access_token(self) -> dict[str, Any]:
+        if not self.refresh_token:
+            raise RuntimeError("Cannot refresh Trakt token without a refresh token")
+
+        payload = await self._request(
+            "POST",
+            "/oauth/token",
+            json={
+                "refresh_token": self.refresh_token,
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
+                "grant_type": "refresh_token",
+            },
+            authenticated=False,
+        )
+        return self._apply_and_persist_tokens(payload)
+
+    async def get_recent_items(self, limit: int = 10) -> list[dict[str, str]]:
+        payload = await self._request(
+            "GET",
+            "/sync/history",
+            params={"limit": limit},
+            authenticated=True,
+        )
+        return self._normalize_recent_items(payload)
+
+    async def get_user_settings(self) -> dict[str, Any]:
+        """Fetch and normalize the authenticated Trakt user's settings."""
+        payload = await self._request("GET", "/users/settings", authenticated=True)
+        return self._normalize_user_settings(payload)
+
+    async def init_existing_content(self) -> None:
+        movies = await self._request("GET", "/sync/watched/movies", authenticated=True)
+        shows = await self._request("GET", "/sync/watched/shows", authenticated=True)
+        self.existing_content = {
+            "movie": self._normalize_watched_items(movies, "movie"),
+            "tv": self._normalize_watched_items(shows, "show"),
+        }
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json: Optional[dict[str, Any]] = None,
+        authenticated: bool = True,
+        retry_auth: bool = True,
+        retry_rate_limit: bool = True,
+    ) -> Any:
+        if authenticated:
+            await self._refresh_if_needed()
+
+        url = path if path.startswith("http") else f"{self.BASE_URL}{path}"
+        session = await self._get_session()
+        request_method = getattr(session, method.lower())
+        kwargs: dict[str, Any] = {"headers": self._headers(authenticated)}
+        if params is not None:
+            kwargs["params"] = params
+        if json is not None:
+            kwargs["json"] = json
+
+        try:
+            async with request_method(url, **kwargs) as response:
+                if response.status in self.HTTP_OK:
+                    return await response.json()
+
+                if response.status == 429 and retry_rate_limit:
+                    retry_after = self._parse_retry_after(response.headers.get("Retry-After"))
+                    if retry_after > 0:
+                        await asyncio.sleep(retry_after)
+                    return await self._request(
+                        method,
+                        path,
+                        params=params,
+                        json=json,
+                        authenticated=authenticated,
+                        retry_auth=retry_auth,
+                        retry_rate_limit=False,
+                    )
+
+                if response.status == 401 and authenticated and retry_auth:
+                    await self.refresh_access_token()
+                    return await self._request(
+                        method,
+                        path,
+                        params=params,
+                        json=json,
+                        authenticated=authenticated,
+                        retry_auth=False,
+                        retry_rate_limit=retry_rate_limit,
+                    )
+
+                body = await response.text()
+                raise RuntimeError(f"Trakt API request failed: {method} {url} returned {response.status}: {body}")
+        except aiohttp.ClientError as exc:
+            raise RuntimeError(f"Trakt API request failed: {method} {url}: {exc}") from exc
+
+    async def _refresh_if_needed(self) -> None:
+        if not self.refresh_token or not self.expires_at:
+            return
+        if self.expires_at <= int(time.time()) + self.REFRESH_WINDOW_SECONDS:
+            await self.refresh_access_token()
+
+    def _apply_and_persist_tokens(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.access_token = payload.get("access_token", self.access_token)
+        self.refresh_token = payload.get("refresh_token", self.refresh_token)
+        expires_in = int(payload.get("expires_in") or 0)
+        if expires_in:
+            self.expires_at = int(time.time()) + expires_in
+
+        if self.link_id and self.token_source == "manual_oauth":
+            self.db.update_trakt_oauth_tokens(
+                self.link_id,
+                self.access_token,
+                self.refresh_token,
+                self.expires_at,
+            )
+
+        result = dict(payload)
+        result["expires_at"] = self.expires_at
+        return result
+
+    @staticmethod
+    def _parse_retry_after(value: Optional[str]) -> int:
+        try:
+            return max(0, int(value or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def _normalize_recent_items(self, payload: list[dict[str, Any]]) -> list[dict[str, str]]:
+        items = []
+        seen: dict[tuple[str, str], int] = {}
+        for entry in payload or []:
+            entry_type = entry.get("type")
+            if entry_type == "movie":
+                normalized = self._normalize_media_item(entry.get("movie"), "movie")
+            elif entry_type in ("episode", "show"):
+                normalized = self._normalize_media_item(entry.get("show"), "tv")
+            else:
+                normalized = None
+
+            if not normalized:
+                continue
+
+            watched_at_raw = entry.get("watched_at")
+            watched_at = self._parse_iso(watched_at_raw) if watched_at_raw else 0
+
+            key = (normalized["media_type"], normalized["tmdb_id"])
+            if key in seen:
+                if watched_at <= seen[key]:
+                    continue
+                items = [s for s in items if (s["media_type"], s["tmdb_id"]) != key]
+            seen[key] = watched_at
+            normalized["watched_at"] = watched_at
+            items.append(normalized)
+        return items
+
+    @staticmethod
+    def _parse_iso(ts: Optional[str]) -> int:
+        """Parse ISO 8601 timestamp to Unix timestamp."""
+        if not ts:
+            return 0
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            return int(dt.timestamp())
+        except (ValueError, TypeError):
+            return 0
+
+    @staticmethod
+    def _normalize_media_item(item: Optional[dict[str, Any]], media_type: str) -> Optional[dict[str, str]]:
+        if not item:
+            return None
+        tmdb_id = item.get("ids", {}).get("tmdb")
+        if not tmdb_id:
+            return None
+        title = item.get("title") or item.get("name") or ""
+        return {
+            "tmdb_id": str(tmdb_id),
+            "media_type": media_type,
+            "title": title,
+            "year": item.get("year"),
+        }
+
+    @staticmethod
+    def _normalize_watched_items(payload: list[dict[str, Any]], item_key: str) -> list[dict[str, str]]:
+        normalized = []
+        seen = set()
+        for entry in payload or []:
+            item = entry.get(item_key) or {}
+            tmdb_id = item.get("ids", {}).get("tmdb")
+            if not tmdb_id:
+                continue
+            tmdb_id = str(tmdb_id)
+            if tmdb_id in seen:
+                continue
+            seen.add(tmdb_id)
+            normalized.append({
+                "tmdb_id": tmdb_id,
+                "title": item.get("title") or item.get("name") or "",
+                "year": item.get("year"),
+            })
+        return normalized
+
+    @staticmethod
+    def _normalize_user_settings(payload: Optional[dict[str, Any]]) -> dict[str, Any]:
+        payload = payload or {}
+        user = payload.get("user") if isinstance(payload.get("user"), dict) else payload
+        ids = user.get("ids") if isinstance(user.get("ids"), dict) else {}
+        username = user.get("username") or user.get("name") or user.get("slug") or ids.get("slug") or ""
+        trakt_user_id = ids.get("uuid") or ids.get("slug") or ids.get("trakt") or user.get("id")
+        if trakt_user_id is None:
+            trakt_user_id = username
+        return {
+            "trakt_user_id": str(trakt_user_id) if trakt_user_id is not None else "",
+            "trakt_username": str(username) if username is not None else "",
+        }

--- a/api_service/test/test_automate_process.py
+++ b/api_service/test/test_automate_process.py
@@ -62,6 +62,11 @@ BASE_ENV = {
     'PLEX_API_URL': 'http://plex.local',
     'PLEX_TOKEN': 'plex_tok',
     'PLEX_LIBRARIES': [],
+    'TRAKT_CLIENT_ID': 'trakt_client_id',
+    'TRAKT_CLIENT_SECRET': 'trakt_secret',
+    'TRAKT_ACCESS_TOKEN': 'trakt_access',
+    'TRAKT_REFRESH_TOKEN': 'trakt_refresh',
+    'TRAKT_EXPIRES_AT': 1234567890,
 }
 
 

--- a/api_service/test/test_config.py
+++ b/api_service/test/test_config.py
@@ -1,16 +1,19 @@
 import os
+import json
 import tempfile
 import unittest
 import yaml
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from test import _verbose_dict_compare
 from api_service.config.config import (
     load_env_vars, save_env_vars, get_default_values,
     get_config_values, get_config_sections, get_config_section,
     save_config_section, clear_env_vars, save_session_token, is_setup_complete,
-    invalidate_config_cache,
+    invalidate_config_cache, INTEGRATION_TO_FLAT,
 )
+from api_service.db.database_manager import DatabaseManager
+from api_service.services import config_service
 
 
 class TestConfig(unittest.TestCase):
@@ -89,6 +92,11 @@ class TestConfig(unittest.TestCase):
         "OPENAI_API_KEY": "openai123abc",
         "OPENAI_BASE_URL": "https://api.openai.com/v1",
         "LLM_MODEL": "gpt-4-0613",
+        "TRAKT_CLIENT_ID": "trakt-client-id",
+        "TRAKT_CLIENT_SECRET": "trakt-client-secret",
+        "TRAKT_ACCESS_TOKEN": "trakt-access-token",
+        "TRAKT_REFRESH_TOKEN": "trakt-refresh-token",
+        "TRAKT_EXPIRES_AT": 1234567890,
         "SEER_REQUEST_DELAY": 0.5,
         "FILTER_INCLUDE_TVOD": "false",
         "ALLOW_REGISTRATION": False,
@@ -105,11 +113,23 @@ class TestConfig(unittest.TestCase):
         self._patch.start()
         self._db_patch = patch('api_service.db.database_manager.DatabaseManager')
         self._db_manager_cls = self._db_patch.start()
+        self._config_service_db_patch = patch(
+            'api_service.services.config_service.DatabaseManager',
+            self._db_manager_cls,
+        )
+        self._config_service_db_patch.start()
         self._db_manager_cls.return_value.get_all_integrations.return_value = {}
+        # _sanitize_integration_config is a pure static helper (no DB I/O); keep
+        # the real implementation on the mocked class so config import/export
+        # still strips Trakt account tokens as in production.
+        self._db_manager_cls._sanitize_integration_config = staticmethod(
+            DatabaseManager._sanitize_integration_config
+        )
         invalidate_config_cache()
 
     def tearDown(self):
         invalidate_config_cache()
+        self._config_service_db_patch.stop()
         self._db_patch.stop()
         self._patch.stop()
         os.unlink(self._tmp.name)
@@ -159,11 +179,240 @@ class TestConfig(unittest.TestCase):
         self._db_manager_cls.return_value.get_all_integrations.return_value = {
             'tmdb': {'api_key': 'db_tmdb'},
             'jellyfin': {'api_url': 'http://jf', 'api_key': 'jf_token'},
+            'trakt': {
+                'client_id': 'trakt_id',
+                'client_secret': 'trakt_secret',
+                'access_token': 'trakt_access',
+                'refresh_token': 'trakt_refresh',
+                'expires_at': 12345,
+            },
         }
         config = load_env_vars(force_reload=True)
         self.assertEqual(config['TMDB_API_KEY'], 'db_tmdb')
         self.assertEqual(config['JELLYFIN_API_URL'], 'http://jf')
         self.assertEqual(config['JELLYFIN_TOKEN'], 'jf_token')
+        self.assertEqual(config['TRAKT_CLIENT_ID'], 'trakt_id')
+        self.assertEqual(config['TRAKT_CLIENT_SECRET'], 'trakt_secret')
+        self.assertEqual(config['TRAKT_ACCESS_TOKEN'], '')
+        self.assertEqual(config['TRAKT_REFRESH_TOKEN'], '')
+        self.assertIsNone(config['TRAKT_EXPIRES_AT'])
+
+    def test_trakt_defaults_and_integration_mapping_are_present(self):
+        defaults = get_config_values()
+        self.assertEqual(defaults['TRAKT_CLIENT_ID'], '')
+        self.assertEqual(defaults['TRAKT_CLIENT_SECRET'], '')
+        self.assertEqual(defaults['TRAKT_ACCESS_TOKEN'], '')
+        self.assertEqual(defaults['TRAKT_REFRESH_TOKEN'], '')
+        self.assertIsNone(defaults['TRAKT_EXPIRES_AT'])
+        self.assertEqual(INTEGRATION_TO_FLAT['trakt'], {
+            'client_id': 'TRAKT_CLIENT_ID',
+            'client_secret': 'TRAKT_CLIENT_SECRET',
+        })
+
+    def test_trakt_is_valid_when_client_credentials_are_present(self):
+        self.assertTrue(DatabaseManager._is_integration_valid(
+            'trakt',
+            {'client_id': 'cid', 'client_secret': 'secret'},
+        ))
+        self.assertFalse(DatabaseManager._is_integration_valid(
+            'trakt',
+            {'client_id': 'cid', 'client_secret': ''},
+        ))
+
+    def test_migrate_integrations_from_config_includes_only_trakt_app_credentials(self):
+        manager = object.__new__(DatabaseManager)
+        manager.logger = unittest.mock.MagicMock()
+        manager.get_integration = unittest.mock.MagicMock(return_value=None)
+        manager.set_integration = unittest.mock.MagicMock()
+
+        with patch('api_service.db.database_manager.load_env_vars', return_value={
+            'TRAKT_CLIENT_ID': 'cid',
+            'TRAKT_CLIENT_SECRET': 'secret',
+            'TRAKT_ACCESS_TOKEN': 'access',
+            'TRAKT_REFRESH_TOKEN': 'refresh',
+            'TRAKT_EXPIRES_AT': 12345,
+        }):
+            manager.migrate_integrations_from_config()
+
+        manager.set_integration.assert_called_once_with('trakt', {
+            'client_id': 'cid',
+            'client_secret': 'secret',
+        })
+
+    def test_migrate_integrations_from_config_purges_stored_legacy_trakt_tokens(self):
+        import api_service.db.database_manager as dm_mod
+
+        real_db_cls = DatabaseManager
+        real_db_cls._instance = None
+        fd, db_file = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        path_patch = patch.object(dm_mod, 'DB_PATH', db_file)
+        env_patch = patch(
+            'api_service.db.database_manager.load_env_vars',
+            return_value={'DB_TYPE': 'sqlite'},
+        )
+        path_patch.start()
+        env_patch.start()
+
+        try:
+            manager = real_db_cls()
+            with manager.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "INSERT INTO integrations (service, config_json) VALUES (?, ?)",
+                    (
+                        'trakt',
+                        json.dumps({
+                            'client_id': 'cid',
+                            'client_secret': 'secret',
+                            'access_token': 'legacy-access',
+                            'refresh_token': 'legacy-refresh',
+                            'expires_at': 12345,
+                        }),
+                    ),
+                )
+                conn.commit()
+
+            env_patch.stop()
+            env_patch = patch(
+                'api_service.db.database_manager.load_env_vars',
+                return_value={
+                    'TRAKT_CLIENT_ID': 'cid',
+                    'TRAKT_CLIENT_SECRET': 'secret',
+                    'TRAKT_ACCESS_TOKEN': 'new-access',
+                    'TRAKT_REFRESH_TOKEN': 'new-refresh',
+                    'TRAKT_EXPIRES_AT': 67890,
+                },
+            )
+            env_patch.start()
+            manager.migrate_integrations_from_config()
+
+            with manager.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute("SELECT config_json FROM integrations WHERE service = ?", ('trakt',))
+                stored = json.loads(cursor.fetchone()[0])
+
+            self.assertEqual(stored, {
+                'client_id': 'cid',
+                'client_secret': 'secret',
+            })
+        finally:
+            real_db_cls._instance = None
+            env_patch.stop()
+            path_patch.stop()
+            try:
+                os.unlink(db_file)
+            except FileNotFoundError:
+                pass
+
+    def test_config_service_classifies_trakt_keys_as_db_integration_keys(self):
+        for key in (
+            'TRAKT_CLIENT_ID',
+            'TRAKT_CLIENT_SECRET',
+        ):
+            self.assertIn(key, config_service._DB_INTEGRATION_KEYS)
+            self.assertNotIn(key, config_service._VALID_SETTING_KEYS)
+        for key in (
+            'TRAKT_ACCESS_TOKEN',
+            'TRAKT_REFRESH_TOKEN',
+            'TRAKT_EXPIRES_AT',
+        ):
+            self.assertNotIn(key, config_service._DB_INTEGRATION_KEYS)
+            self.assertNotIn(key, config_service._VALID_SETTING_KEYS)
+
+    def test_config_export_strips_legacy_trakt_account_tokens_from_integrations(self):
+        self._db_manager_cls.return_value.get_all_integrations.return_value = {
+            'trakt': {
+                'client_id': 'cid',
+                'client_secret': 'secret',
+                'access_token': 'legacy-access',
+                'refresh_token': 'legacy-refresh',
+                'expires_at': 12345,
+            },
+        }
+
+        exported = config_service.ConfigService.export_config()
+
+        self.assertEqual(exported['integrations']['trakt'], {
+            'client_id': 'cid',
+            'client_secret': 'secret',
+        })
+        self.assertNotIn('TRAKT_ACCESS_TOKEN', exported['settings'])
+        self.assertNotIn('TRAKT_REFRESH_TOKEN', exported['settings'])
+        self.assertNotIn('TRAKT_EXPIRES_AT', exported['settings'])
+
+    def test_config_import_strips_trakt_account_tokens_before_writing_integration(self):
+        self._db_manager_cls.return_value.get_all_integrations.return_value = {}
+        self._db_manager_cls.return_value.refresh_config.return_value = None
+
+        config_service.ConfigService.import_config({
+            'version': config_service.CURRENT_VERSION,
+            'integrations': {
+                'trakt': {
+                    'client_id': 'cid',
+                    'client_secret': 'secret',
+                    'access_token': 'legacy-access',
+                    'refresh_token': 'legacy-refresh',
+                    'expires_at': 12345,
+                },
+            },
+            'settings': {},
+        })
+
+        self._db_manager_cls.return_value.set_integration.assert_called_once_with('trakt', {
+            'client_id': 'cid',
+            'client_secret': 'secret',
+        })
+
+    def test_config_import_log_redacts_secret_like_keys(self):
+        self._db_manager_cls.return_value.get_all_integrations.return_value = {}
+        self._db_manager_cls.return_value.refresh_config.return_value = None
+
+        with patch.object(config_service, 'logger') as logger:
+            config_service.ConfigService.import_config({
+                'version': config_service.CURRENT_VERSION,
+                'integrations': {
+                    'trakt': {
+                        'client_id': 'cid',
+                        'client_secret': 'secret',
+                    },
+                },
+                'settings': {},
+            })
+
+        info_calls = [
+            call for call in logger.info.call_args_list
+            if call.args and call.args[0] == "Importing integration '%s' %s"
+        ]
+        self.assertEqual(len(info_calls), 1)
+        safe_payload = info_calls[0].args[2]
+        self.assertEqual(safe_payload['client_id'], 'cid')
+        self.assertEqual(safe_payload['client_secret'], '***')
+
+    def test_config_status_exposes_trakt_app_configured_without_secret_values(self):
+        from api_service.blueprints.config.routes import config_bp
+        from flask import Flask
+
+        app = Flask(__name__)
+        app.register_blueprint(config_bp, url_prefix='/api/config')
+        db = MagicMock()
+        db.get_all_integrations.return_value = {
+            'trakt': {'client_id': 'cid', 'client_secret': 'secret'},
+        }
+
+        with patch('api_service.blueprints.config.routes.load_env_vars', return_value={
+            'TMDB_API_KEY': 'tmdb',
+            'SELECTED_SERVICE': 'trakt',
+            'DB_TYPE': 'sqlite',
+        }), patch('api_service.blueprints.config.routes.DatabaseManager', return_value=db):
+            response = app.test_client().get('/api/config/status')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertTrue(body['trakt_app_configured'])
+        self.assertNotIn('TRAKT_CLIENT_ID', body)
+        self.assertNotIn('TRAKT_CLIENT_SECRET', body)
 
     def test_load_env_vars_cache_is_used_until_invalidated(self):
         self._db_manager_cls.return_value.get_all_integrations.return_value = {

--- a/api_service/test/test_handler_trakt_augmentation.py
+++ b/api_service/test/test_handler_trakt_augmentation.py
@@ -1,0 +1,141 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api_service.handler.jellyfin_handler import JellyfinHandler
+from api_service.services.trakt.media_user_augmentor import TraktAugmentation
+
+
+def _jellyfin_handler(augmentor):
+    jf_client = MagicMock()
+    jf_client.existing_content = {"movie": [], "tv": []}
+    handler = JellyfinHandler(
+        jf_client, MagicMock(), MagicMock(), logging.getLogger("test"),
+        max_similar_movie=2, max_similar_tv=2,
+        selected_users=[{"id": "jf-1", "name": "alice"}],
+        use_llm=False,
+        trakt_augmentor=augmentor,
+    )
+    return handler
+
+
+def test_seed_and_skip_merge_for_linked_user():
+    augmentor = MagicMock()
+    augmentor.augment = AsyncMock(return_value=TraktAugmentation(
+        seed_items=[{"tmdb_id": "11", "media_type": "movie", "title": "A"}],
+        watched_ids={"movie": {"99"}, "tv": {"77"}},
+    ))
+    handler = _jellyfin_handler(augmentor)
+
+    seeds = asyncio.run(handler._augment_user_trakt(1))
+
+    # Trakt fully-watched ids joined the skip set
+    assert "99" in handler.existing_content_sets["movie"]
+    assert "77" in handler.existing_content_sets["tv"]
+    # Seeds are returned for the caller to process additively
+    assert len(seeds) == 1
+    assert seeds[0]["tmdb_id"] == "11"
+
+
+def test_unlinked_user_is_noop():
+    augmentor = MagicMock()
+    augmentor.augment = AsyncMock(return_value=None)
+    handler = _jellyfin_handler(augmentor)
+
+    seeds = asyncio.run(handler._augment_user_trakt(1))
+
+    assert seeds == []
+    assert handler.existing_content_sets.get("movie", set()) == set()
+
+
+def test_no_augmentor_is_noop():
+    handler = _jellyfin_handler(None)
+    seeds = asyncio.run(handler._augment_user_trakt(1))
+    assert seeds == []
+
+
+def test_seed_processing_failure_propagates():
+    """_process_seed propagates tmdb failures to the caller."""
+    handler = _jellyfin_handler(MagicMock())
+    handler.tmdb_client.get_metadata = AsyncMock(side_effect=RuntimeError("tmdb down"))
+    handler.request_similar_media = AsyncMock()
+
+    seed = {"tmdb_id": "11", "media_type": "movie", "title": "A"}
+    with pytest.raises(RuntimeError, match="tmdb down"):
+        asyncio.run(handler._process_seed({"id": "jf-1"}, seed))
+    handler.request_similar_media.assert_not_awaited()
+
+
+def test_process_seed_requests_similar():
+    """_process_seed resolves, finds similar, and requests via Seer."""
+    augmentor = MagicMock()
+    augmentor.augment = AsyncMock(return_value=TraktAugmentation(
+        seed_items=[{"tmdb_id": "11", "media_type": "movie", "title": "A"}],
+        watched_ids={"movie": set(), "tv": set()},
+    ))
+    handler = _jellyfin_handler(augmentor)
+    handler.tmdb_client.get_metadata = AsyncMock(return_value={"id": 11})
+    handler.tmdb_client.find_similar_movies = AsyncMock(return_value=[{"id": 22}])
+    handler.request_similar_media = AsyncMock()
+
+    seed = {"tmdb_id": "11", "media_type": "movie", "title": "A"}
+    asyncio.run(handler._process_seed({"id": "jf-1"}, seed))
+
+    handler.request_similar_media.assert_awaited_once()
+    awaited_args = handler.request_similar_media.await_args.args
+    assert awaited_args[1] == "movie"
+
+
+def test_collect_trakt_seeds_returns_seeds_not_processes():
+    """_collect_trakt_seeds_for_user fetches but does NOT process seeds."""
+    augmentor = MagicMock()
+    augmentor.augment = AsyncMock(return_value=TraktAugmentation(
+        seed_items=[{"tmdb_id": "11", "media_type": "movie", "title": "A"}],
+        watched_ids={"movie": {"99"}, "tv": set()},
+    ))
+    handler = _jellyfin_handler(augmentor)
+
+    with patch("api_service.handler.jellyfin_handler.DatabaseManager") as DM:
+        DM.return_value.upsert_media_user_identity.return_value = {"id": 1}
+        seeds = asyncio.run(handler._collect_trakt_seeds_for_user(
+            {"id": "jf-1", "name": "alice"}
+        ))
+
+    assert len(seeds) == 1
+    assert seeds[0]["tmdb_id"] == "11"
+    # Watched IDs should be merged into skip set by _augment_user_trakt
+    assert "99" in handler.existing_content_sets["movie"]
+
+
+def test_merge_seeds_dedup_and_sort():
+    """_merge_seeds deduplicates by (media_type, tmdb_id) and sorts by date."""
+    handler = _jellyfin_handler(None)
+    seeds = [
+        {"tmdb_id": "1", "media_type": "movie", "date": 1000, "title": "Old"},
+        {"tmdb_id": "2", "media_type": "movie", "date": 3000, "title": "New"},
+        {"tmdb_id": "1", "media_type": "movie", "date": 2000, "title": "Dup"},  # dupe tmdb_id, newer
+        {"tmdb_id": "3", "media_type": "tv", "date": 500, "title": "TV"},
+    ]
+    merged = handler._merge_seeds(seeds)
+    assert len(merged) == 3
+    # Newest first, dupe keeps newest entry
+    assert merged[0]["title"] == "New"
+    assert merged[1]["title"] == "Dup"
+    assert merged[2]["title"] == "TV"
+
+
+def test_merge_seeds_caps_to_max_content():
+    """_merge_seeds respects max_content cap."""
+    handler = _jellyfin_handler(None)
+    handler.max_content = 2
+    seeds = [
+        {"tmdb_id": str(i), "media_type": "movie", "date": i}
+        for i in range(10)
+    ]
+    merged = handler._merge_seeds(seeds)
+    assert len(merged) == 2
+    # Newest first (highest date)
+    assert merged[0]["date"] == 9
+    assert merged[1]["date"] == 8

--- a/api_service/test/test_jobs_routes_owner.py
+++ b/api_service/test/test_jobs_routes_owner.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+from api_service.blueprints.jobs import routes as jobs_routes
+
+
+def _job_payload():
+    return {
+        "name": "Owner scoped recommendations",
+        "job_type": "recommendation",
+        "media_type": "both",
+        "filters": {},
+        "schedule_type": "preset",
+        "schedule_value": "daily",
+        "max_results": 10,
+        "user_ids": ["media-user"],
+    }
+
+
+def test_create_job_sets_owner_id_none_when_no_current_user(monkeypatch):
+    repository = MagicMock()
+    repository.create_job.return_value = 1
+    monkeypatch.setattr(jobs_routes, "JobRepository", MagicMock(return_value=repository))
+    monkeypatch.setattr(jobs_routes, "get_job_manager", MagicMock())
+
+    app = Flask(__name__)
+    app.register_blueprint(jobs_routes.jobs_bp, url_prefix="/api/jobs")
+
+    with app.test_client() as client:
+        response = client.post("/api/jobs", json=_job_payload())
+
+    assert response.status_code == 201
+    repository.create_job.assert_called_once()
+    call_args = repository.create_job.call_args[0][0]
+    assert call_args["owner_id"] is None

--- a/api_service/test/test_media_handler_integration.py
+++ b/api_service/test/test_media_handler_integration.py
@@ -220,9 +220,18 @@ class FakePlexClient(AsyncContextClient):
         self.recent_items = recent_items or deepcopy(PLEX_RECENT_ITEMS)
         self.existing_content = {}
         self.init_existing_content = AsyncMock()
+        self.get_metadata_provider_id = AsyncMock(side_effect=self._resolve_tmdb)
 
     async def get_recent_items(self):
         return deepcopy(self.recent_items)
+
+    async def _resolve_tmdb(self, key):
+        """Map rating keys to fake TMDB IDs: key /1 -> 10, /2 -> 20"""
+        if "1" in str(key):
+            return "10"
+        if "2" in str(key):
+            return "20"
+        return None
 
 
 class FakeJellyfinClient(AsyncContextClient):
@@ -574,7 +583,7 @@ async def test_recommendation_automation_dry_run_preserves_async_flow_and_logs(m
     assert {item["title"] for item in result.dry_run_items} == expected_titles
     assert llm_mock.await_count == 2
     assert "Starting recommendation job" in caplog.text
-    assert "Advanced Algorithm enabled. Generating recommendations using LLM." in caplog.text
+    assert "LLM matched" in caplog.text
     assert "Job completed: 2 would be requested" in caplog.text
     assert "TypeError" not in caplog.text
 

--- a/api_service/test/test_media_user_augmentor.py
+++ b/api_service/test/test_media_user_augmentor.py
@@ -1,0 +1,118 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from api_service.services.trakt.media_user_augmentor import MediaUserTraktAugmentor
+
+
+class FakeTraktClient:
+    last = None
+
+    def __init__(self, client_id, client_secret, access_token="", refresh_token="",
+                 expires_at=None, session=None, db=None, link_id=None,
+                 token_source="manual_oauth", **_):
+        self.link_id = link_id
+        self.token_source = token_source
+        self.existing_content = {"movie": [], "tv": []}
+        FakeTraktClient.last = self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get_recent_items(self, limit=10):
+        return [{"tmdb_id": "11", "media_type": "movie", "title": "A", "year": 2001}]
+
+    async def init_existing_content(self):
+        self.existing_content = {
+            "movie": [{"tmdb_id": "11"}, {"tmdb_id": "22"}],
+            "tv": [{"tmdb_id": "33"}],
+        }
+
+
+def _db_with_link_and_tokens(status="connected"):
+    db = MagicMock()
+    db.get_trakt_account_link.return_value = {
+        "id": 1,
+        "media_user_identity_id": 1, "connected": True,
+        "status": status,
+        "token_source": "manual_oauth",
+    }
+    db.get_trakt_oauth_tokens.return_value = {
+        "access_token": "acc", "refresh_token": "ref", "expires_at": 999,
+    }
+    db.get_enabled_trakt_sources.return_value = [
+        {"source_type": "watched_history", "use_as_seed": True, "use_as_exclusion": True},
+    ]
+    return db
+
+
+def test_augment_returns_seeds_and_watched_ids():
+    db = _db_with_link_and_tokens()
+    aug = MediaUserTraktAugmentor("cid", "secret", db=db)
+    with patch("api_service.services.trakt.media_user_augmentor.TraktClient", FakeTraktClient):
+        result = asyncio.run(aug.augment(1))
+    assert result is not None
+    assert result.seed_items == [{"tmdb_id": "11", "media_type": "movie", "title": "A", "year": 2001}]
+    assert result.watched_ids == {"movie": {"11", "22"}, "tv": {"33"}}
+    assert FakeTraktClient.last.link_id == 1
+    assert FakeTraktClient.last.token_source == "manual_oauth"
+
+
+def test_augment_no_account_returns_none():
+    db = MagicMock()
+    db.get_trakt_account_link.return_value = None
+    aug = MediaUserTraktAugmentor("cid", "secret", db=db)
+    with patch("api_service.services.trakt.media_user_augmentor.TraktClient", FakeTraktClient):
+        assert asyncio.run(aug.augment(1)) is None
+
+
+def test_augment_skips_revoked_and_errored():
+    aug = MediaUserTraktAugmentor("cid", "secret", db=_db_with_link_and_tokens(status="revoked"))
+    with patch("api_service.services.trakt.media_user_augmentor.TraktClient", FakeTraktClient):
+        assert asyncio.run(aug.augment(1)) is None
+
+
+def test_augment_get_recent_items_failure_returns_watched_ids():
+    """get_recent_items fails internally (returns []) but watched_ids still succeed."""
+    db = _db_with_link_and_tokens()
+
+    class Boom(FakeTraktClient):
+        async def get_recent_items(self, limit=10):
+            raise RuntimeError("trakt 401")
+
+    aug = MediaUserTraktAugmentor("cid", "secret", db=db)
+    with patch("api_service.services.trakt.media_user_augmentor.TraktClient", Boom):
+        result = asyncio.run(aug.augment(1))
+    assert result is not None
+    assert result.seed_items == []
+    assert result.watched_ids == {"movie": {"11", "22"}, "tv": {"33"}}
+    db.mark_trakt_account_link_error.assert_not_called()
+
+
+def test_augment_disabled_without_credentials():
+    aug = MediaUserTraktAugmentor("", "", db=_db_with_link_and_tokens())
+    assert aug.enabled is False
+    assert asyncio.run(aug.augment(1)) is None
+
+
+@patch("api_service.services.trakt.media_user_augmentor.DatabaseManager")
+def test_from_env_returns_none_without_credentials(_db):
+    assert MediaUserTraktAugmentor.from_env({}) is None
+    assert MediaUserTraktAugmentor.from_env({"TRAKT_CLIENT_ID": "", "TRAKT_CLIENT_SECRET": ""}) is None
+
+
+@patch("api_service.services.trakt.media_user_augmentor.DatabaseManager")
+def test_from_env_builds_enabled_augmentor(_db):
+    aug = MediaUserTraktAugmentor.from_env({"TRAKT_CLIENT_ID": "cid", "TRAKT_CLIENT_SECRET": "secret"})
+    assert aug is not None
+    assert aug.enabled is True
+
+
+@patch("api_service.services.trakt.media_user_augmentor.DatabaseManager")
+def test_from_env_falls_back_to_integrations_block(_db):
+    env = {"integrations": {"trakt": {"client_id": "cid", "client_secret": "secret"}}}
+    aug = MediaUserTraktAugmentor.from_env(env)
+    assert aug is not None
+    assert aug.enabled is True

--- a/api_service/test/test_media_user_trakt_accounts.py
+++ b/api_service/test/test_media_user_trakt_accounts.py
@@ -1,0 +1,304 @@
+"""Test the flat Trakt data layer tables and DatabaseManager methods.
+
+Tables tested: media_user_identities, trakt_account_links, trakt_oauth_tokens,
+trakt_sources. Trakt links and sources are keyed directly by the media-user
+identity (provider, external_user_id) — there is no separate profile layer.
+"""
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from api_service.db.database_manager import DatabaseManager
+
+
+@pytest.fixture
+def db():
+    import api_service.db.database_manager as dm_mod
+
+    dm_mod.DatabaseManager._instance = None
+    fd, db_file = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    path_patch = patch.object(dm_mod, "DB_PATH", db_file)
+    env_patch = patch(
+        "api_service.db.database_manager.load_env_vars",
+        return_value={"DB_TYPE": "sqlite"},
+    )
+    path_patch.start()
+    env_patch.start()
+
+    manager = DatabaseManager()
+    try:
+        yield manager
+    finally:
+        dm_mod.DatabaseManager._instance = None
+        path_patch.stop()
+        env_patch.stop()
+        try:
+            os.unlink(db_file)
+        except FileNotFoundError:
+            pass
+
+
+def _identity_id(db, provider="jellyfin", external_user_id="jf-1", username="alice"):
+    return db.upsert_media_user_identity(provider, external_user_id, username)["id"]
+
+
+# ---- Table existence ----------------------------------------------------------
+
+NEW_TABLES = [
+    "media_user_identities",
+    "trakt_account_links",
+    "trakt_oauth_tokens",
+    "trakt_sources",
+]
+
+
+@pytest.mark.parametrize("table", NEW_TABLES)
+def test_new_tables_exist(db, table):
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        )
+        assert cursor.fetchone() is not None, f"Table {table} missing"
+
+
+def test_removed_tables_do_not_exist(db):
+    """The over-built profile layer must be gone."""
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        for table in ("recommendation_profiles", "profile_media_user_identities"):
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            )
+            assert cursor.fetchone() is None, f"Table {table} should be removed"
+
+
+# ---- media_user_identities ----------------------------------------------------
+
+def test_upsert_media_user_identity_is_idempotent(db):
+    first = db.upsert_media_user_identity("jellyfin", "jf-1", "alice")
+    second = db.upsert_media_user_identity("jellyfin", "jf-1", "alice_updated")
+    assert first["id"] == second["id"]
+    assert first["provider"] == "jellyfin"
+    assert first["external_user_id"] == "jf-1"
+    # Username should be updated on re-upsert
+    updated = db.get_media_user_identity("jellyfin", "jf-1")
+    assert updated["external_username"] == "alice_updated"
+
+
+def test_upsert_media_user_identity_returns_valid_dict(db):
+    result = db.upsert_media_user_identity("jellyfin", "jf-1", "alice")
+    assert "id" in result
+    assert result["provider"] == "jellyfin"
+    assert result["external_user_id"] == "jf-1"
+    assert result["external_username"] == "alice"
+
+
+def test_get_media_user_identity_returns_correct_row(db):
+    db.upsert_media_user_identity("jellyfin", "jf-1", "alice")
+    identity = db.get_media_user_identity("jellyfin", "jf-1")
+    assert identity["provider"] == "jellyfin"
+    assert identity["external_user_id"] == "jf-1"
+
+
+def test_same_user_id_different_provider_creates_separate_identities(db):
+    a = db.upsert_media_user_identity("jellyfin", "u1", "alice")
+    b = db.upsert_media_user_identity("plex", "u1", "alice")
+    assert a["id"] != b["id"]
+    jf = db.get_media_user_identity("jellyfin", "u1")
+    px = db.get_media_user_identity("plex", "u1")
+    assert jf["provider"] == "jellyfin"
+    assert px["provider"] == "plex"
+
+
+def test_get_media_user_identity_by_id(db):
+    created = db.upsert_media_user_identity("jellyfin", "jf-1", "alice")
+    found = db.get_media_user_identity_by_id(created["id"])
+    assert found is not None
+    assert found["id"] == created["id"]
+
+
+def test_get_media_user_identity_by_id_unknown_returns_none(db):
+    assert db.get_media_user_identity_by_id(999999) is None
+
+
+# ---- trakt_account_links ------------------------------------------------------
+
+def test_upsert_trakt_account_link_is_idempotent(db):
+    identity_id = _identity_id(db)
+
+    first = db.upsert_trakt_account_link(
+        media_user_identity_id=identity_id,
+        trakt_user_id="t-1",
+        trakt_username="trakt_alice",
+        token_source="manual_oauth",
+        status="connected",
+    )
+    second = db.upsert_trakt_account_link(
+        media_user_identity_id=identity_id,
+        trakt_user_id="t-2",
+        trakt_username="trakt_alice_updated",
+        token_source="manual_oauth",
+        status="connected",
+    )
+    # Re-link must return the same (real) link id, not 0 — the returned id is
+    # used as a foreign key for the token upsert that follows.
+    assert first == second
+    assert second > 0
+    link = db.get_trakt_account_link(identity_id)
+    assert link["id"] == second
+    assert link["media_user_identity_id"] == identity_id
+    assert link["trakt_username"] == "trakt_alice_updated"
+    assert link["trakt_user_id"] == "t-2"
+
+
+def test_get_trakt_account_link_unknown_returns_none(db):
+    assert db.get_trakt_account_link(999999) is None
+
+
+def test_get_trakt_account_link_by_id(db):
+    identity_id = _identity_id(db)
+    link_id = db.upsert_trakt_account_link(media_user_identity_id=identity_id, trakt_user_id="t1", trakt_username="u1")
+    found = db.get_trakt_account_link_by_id(link_id)
+    assert found is not None
+    assert found["media_user_identity_id"] == identity_id
+
+
+def test_get_trakt_account_link_by_id_unknown_returns_none(db):
+    assert db.get_trakt_account_link_by_id(999999) is None
+
+
+def test_mark_trakt_account_link_error_for_unknown_identity_returns_false(db):
+    assert db.mark_trakt_account_link_error(999999, "error", "boom") is False
+
+
+def test_mark_trakt_account_link_error_sets_status_and_message(db):
+    identity_id = _identity_id(db)
+    db.upsert_trakt_account_link(media_user_identity_id=identity_id, trakt_user_id="t1", trakt_username="u1", status="connected")
+    assert db.mark_trakt_account_link_error(identity_id, "error", "boom") is True
+    link = db.get_trakt_account_link(identity_id)
+    assert link["connected"] is False
+    assert link["status"] == "error"
+    assert link["last_error"] == "boom"
+
+
+def test_get_all_trakt_account_link_statuses(db):
+    identity_id = _identity_id(db)
+    db.upsert_trakt_account_link(
+        media_user_identity_id=identity_id, trakt_user_id="t1",
+        trakt_username="alice_t", status="connected",
+    )
+
+    rows = db.get_all_trakt_account_link_statuses()
+    assert len(rows) == 1
+    assert rows[0]["trakt_username"] == "alice_t"
+    assert rows[0]["media_user_identity_id"] == identity_id
+    assert rows[0]["connected"] is True
+
+
+def test_unlink_trakt_account(db):
+    identity_id = _identity_id(db)
+    db.upsert_trakt_account_link(media_user_identity_id=identity_id, trakt_user_id="t1", trakt_username="u1")
+    assert db.unlink_trakt_account(identity_id) is True
+    assert db.get_trakt_account_link(identity_id) is None
+    assert db.unlink_trakt_account(identity_id) is False
+
+
+def test_unlink_trakt_account_removes_oauth_tokens(db):
+    """Unlinking must clean up dependent OAuth tokens explicitly (not relying on FK cascade)."""
+    identity_id = _identity_id(db)
+    link_id = db.upsert_trakt_account_link(media_user_identity_id=identity_id, trakt_user_id="t1", trakt_username="u1")
+    db.upsert_trakt_oauth_tokens(link_id, "access", "refresh", datetime.now(timezone.utc) + timedelta(hours=2))
+
+    assert db.get_trakt_oauth_tokens(link_id) is not None
+    assert db.unlink_trakt_account(identity_id) is True
+    assert db.get_trakt_oauth_tokens(link_id) is None
+
+
+# ---- trakt_oauth_tokens -------------------------------------------------------
+
+def test_trakt_oauth_tokens_upsert_and_get(db):
+    identity_id = _identity_id(db)
+    link_id = db.upsert_trakt_account_link(media_user_identity_id=identity_id, trakt_user_id="t1", trakt_username="u1")
+
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
+    db.upsert_trakt_oauth_tokens(link_id, "access", "refresh", expires_at)
+    tokens = db.get_trakt_oauth_tokens(link_id)
+    assert tokens["access_token"] == "access"
+    assert tokens["refresh_token"] == "refresh"
+
+
+def test_trakt_oauth_tokens_upsert_is_idempotent(db):
+    identity_id = _identity_id(db)
+    link_id = db.upsert_trakt_account_link(media_user_identity_id=identity_id, trakt_user_id="t1", trakt_username="u1")
+
+    db.upsert_trakt_oauth_tokens(link_id, "a1", "r1", None)
+    db.upsert_trakt_oauth_tokens(link_id, "a2", "r2", None)
+    tokens = db.get_trakt_oauth_tokens(link_id)
+    assert tokens["access_token"] == "a2"
+    assert tokens["refresh_token"] == "r2"
+
+
+def test_update_trakt_oauth_tokens_persists_new_values(db):
+    identity_id = _identity_id(db)
+    link_id = db.upsert_trakt_account_link(media_user_identity_id=identity_id, trakt_user_id="t1", trakt_username="u1")
+    db.upsert_trakt_oauth_tokens(link_id, "old", "old-r", None)
+
+    assert db.update_trakt_oauth_tokens(link_id, "new", "new-r", 123456) is True
+    tokens = db.get_trakt_oauth_tokens(link_id)
+    assert tokens["access_token"] == "new"
+    assert tokens["refresh_token"] == "new-r"
+    assert tokens["expires_at"] == 123456
+
+
+def test_update_trakt_oauth_tokens_for_missing_link_returns_false(db):
+    assert db.update_trakt_oauth_tokens(999999, "a", "b", None) is False
+
+
+def test_delete_trakt_oauth_tokens(db):
+    identity_id = _identity_id(db)
+    link_id = db.upsert_trakt_account_link(media_user_identity_id=identity_id, trakt_user_id="t1", trakt_username="u1")
+    db.upsert_trakt_oauth_tokens(link_id, "a", "r", None)
+    assert db.delete_trakt_oauth_tokens(link_id) is True
+    assert db.get_trakt_oauth_tokens(link_id) is None
+    assert db.delete_trakt_oauth_tokens(link_id) is False
+
+
+# ---- trakt_sources ------------------------------------------------------------
+
+def test_upsert_trakt_source_respects_unique_constraint(db):
+    identity_id = _identity_id(db)
+    db.upsert_trakt_source(
+        media_user_identity_id=identity_id, source_type="watched_history",
+        source_key="watched_history", enabled=True,
+    )
+    db.upsert_trakt_source(
+        media_user_identity_id=identity_id, source_type="watched_history",
+        source_key="watched_history", enabled=False,
+    )
+    sources = db.get_trakt_sources(identity_id)
+    assert len(sources) == 1
+    assert sources[0]["enabled"] is False
+
+
+def test_get_enabled_trakt_sources(db):
+    identity_id = _identity_id(db)
+    db.upsert_trakt_source(
+        media_user_identity_id=identity_id, source_type="watched_history",
+        source_key="wh", enabled=True,
+    )
+    db.upsert_trakt_source(
+        media_user_identity_id=identity_id, source_type="watchlist",
+        source_key="wl", enabled=False,
+    )
+    enabled = db.get_enabled_trakt_sources(identity_id)
+    assert len(enabled) == 1
+    assert enabled[0]["source_type"] == "watched_history"

--- a/api_service/test/test_trakt_auth_disabled_e2e.py
+++ b/api_service/test/test_trakt_auth_disabled_e2e.py
@@ -1,0 +1,147 @@
+"""End-to-end: profile-based Trakt augmentation under SUGGESTARR_AUTH_DISABLED=true.
+
+Proves the feature works with zero auth_users rows and resolves Trakt by
+profile_id against a real DatabaseManager -- no login-account dependency.
+The Trakt network client is stubbed; the DB is real SQLite.
+"""
+
+import asyncio
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from api_service.db.database_manager import DatabaseManager
+from api_service.services.trakt.media_user_augmentor import MediaUserTraktAugmentor
+
+
+class FakeTraktClient:
+    """Stub TraktClient: no network, deterministic recent + watched history."""
+    last = None
+
+    def __init__(self, client_id, client_secret, access_token="", refresh_token="",
+                 expires_at=None, session=None, db=None, link_id=None,
+                 token_source="manual_oauth", **_):
+        self.link_id = link_id
+        self.token_source = token_source
+        self.existing_content = {"movie": [], "tv": []}
+        FakeTraktClient.last = self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get_recent_items(self, limit=10):
+        return [{"tmdb_id": "11", "media_type": "movie", "title": "A", "year": 2001}]
+
+    async def init_existing_content(self):
+        self.existing_content = {
+            "movie": [{"tmdb_id": "11"}, {"tmdb_id": "22"}],
+            "tv": [{"tmdb_id": "33"}],
+        }
+
+
+@pytest.fixture
+def auth_disabled_db():
+    """Real SQLite DatabaseManager with auth disabled and zero auth_users rows."""
+    import api_service.db.database_manager as dm_mod
+
+    dm_mod.DatabaseManager._instance = None
+    fd, db_file = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    path_patch = patch.object(dm_mod, "DB_PATH", db_file)
+    env_patch = patch(
+        "api_service.db.database_manager.load_env_vars",
+        return_value={"DB_TYPE": "sqlite"},
+    )
+    path_patch.start()
+    env_patch.start()
+    auth_patch = patch.dict(os.environ, {"SUGGESTARR_AUTH_DISABLED": "true"})
+    auth_patch.start()
+
+    manager = DatabaseManager()
+    try:
+        yield manager
+    finally:
+        dm_mod.DatabaseManager._instance = None
+        auth_patch.stop()
+        path_patch.stop()
+        env_patch.stop()
+        try:
+            os.unlink(db_file)
+        except FileNotFoundError:
+            pass
+
+
+def _auth_users_count(db):
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM auth_users")
+        return cursor.fetchone()[0]
+
+
+def _setup_linked_media_user(db):
+    """Create a fully linked media user: identity + link + tokens + source."""
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
+    identity = db.upsert_media_user_identity("jellyfin", "jf-1", "alice")
+    link_id = db.upsert_trakt_account_link(
+        media_user_identity_id=identity["id"],
+        trakt_user_id="trakt-1",
+        trakt_username="alice_trakt",
+        token_source="manual_oauth",
+        status="connected",
+    )
+    db.upsert_trakt_oauth_tokens(link_id, "acc", "ref", expires_at)
+    db.upsert_trakt_source(
+        media_user_identity_id=identity["id"],
+        source_type="watched_history",
+        source_key="watched_history",
+        enabled=True,
+        use_as_seed=True,
+        use_as_exclusion=True,
+    )
+    return identity["id"]
+
+
+def test_linked_media_user_augments_with_zero_auth_users(auth_disabled_db):
+    db = auth_disabled_db
+    assert os.environ.get("SUGGESTARR_AUTH_DISABLED") == "true"
+    assert _auth_users_count(db) == 0
+
+    media_user_identity_id = _setup_linked_media_user(db)
+
+    aug = MediaUserTraktAugmentor("cid", "secret", db=db)
+    with patch(
+        "api_service.services.trakt.media_user_augmentor.TraktClient",
+        FakeTraktClient,
+    ):
+        result = asyncio.run(aug.augment(media_user_identity_id))
+
+    assert result is not None
+    assert result.seed_items == [
+        {"tmdb_id": "11", "media_type": "movie", "title": "A", "year": 2001}
+    ]
+    assert result.watched_ids == {"movie": {"11", "22"}, "tv": {"33"}}
+    assert FakeTraktClient.last.link_id is not None
+    assert FakeTraktClient.last.token_source == "manual_oauth"
+    assert _auth_users_count(db) == 0
+
+
+def test_unlinked_media_user_is_silent_noop(auth_disabled_db):
+    db = auth_disabled_db
+    assert _auth_users_count(db) == 0
+
+    aug = MediaUserTraktAugmentor("cid", "secret", db=db)
+    with patch(
+        "api_service.services.trakt.media_user_augmentor.TraktClient",
+        FakeTraktClient,
+    ):
+        result = asyncio.run(aug.augment(999999))
+
+    assert result is None
+    assert _auth_users_count(db) == 0

--- a/api_service/test/test_trakt_client.py
+++ b/api_service/test/test_trakt_client.py
@@ -1,0 +1,289 @@
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from api_service.services.trakt.trakt_client import (
+    TraktClient,
+    TraktDeviceDenied,
+    TraktDeviceExpired,
+    TraktDevicePending,
+)
+
+
+class FakeResponse:
+    def __init__(self, status, payload=None, headers=None):
+        self.status = status
+        self._payload = payload or {}
+        self.headers = headers or {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return str(self._payload)
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append(("GET", url, kwargs))
+        return self.responses.pop(0)
+
+    def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        return self.responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_request_device_code_posts_client_id():
+    session = FakeSession([
+        FakeResponse(200, {
+            "device_code": "dev-1",
+            "user_code": "ABCD-EFGH",
+            "verification_url": "https://trakt.tv/activate",
+            "expires_in": 600,
+            "interval": 5,
+        })
+    ])
+    client = TraktClient("cid", "secret", session=session)
+
+    result = await client.request_device_code()
+
+    assert result["device_code"] == "dev-1"
+    assert session.calls[0][0] == "POST"
+    assert session.calls[0][1] == "https://api.trakt.tv/oauth/device/code"
+    assert session.calls[0][2]["json"] == {"client_id": "cid"}
+
+
+@pytest.mark.asyncio
+async def test_poll_for_token_updates_instance_without_db_persist_when_no_link_id():
+    session = FakeSession([
+        FakeResponse(200, {
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "expires_in": 7200,
+        })
+    ])
+    db = MagicMock()
+    db.get_integration.return_value = {"client_id": "cid", "client_secret": "secret"}
+    client = TraktClient("cid", "secret", session=session, db=db)
+
+    result = await client.poll_for_token("device-code")
+
+    assert result["access_token"] == "access"
+    assert client.access_token == "access"
+    assert client.refresh_token == "refresh"
+    assert client.expires_at > int(time.time())
+    db.set_integration.assert_not_called()
+    db.update_trakt_oauth_tokens.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_for_token_returns_tokens_on_success():
+    session = FakeSession([
+        FakeResponse(200, {
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "expires_in": 7200,
+        })
+    ])
+    client = TraktClient("cid", "secret", session=session)
+
+    result = await client.poll_for_token("device-code")
+
+    assert result["access_token"] == "access"
+    assert client.access_token == "access"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 429])
+async def test_poll_for_token_raises_pending_on_400_and_429(status):
+    session = FakeSession([FakeResponse(status)])
+    client = TraktClient("cid", "secret", session=session)
+
+    with pytest.raises(TraktDevicePending):
+        await client.poll_for_token("device-code")
+
+
+@pytest.mark.asyncio
+async def test_poll_for_token_raises_expired_on_410():
+    session = FakeSession([FakeResponse(410)])
+    client = TraktClient("cid", "secret", session=session)
+
+    with pytest.raises(TraktDeviceExpired):
+        await client.poll_for_token("device-code")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [418, 409])
+async def test_poll_for_token_raises_denied_on_418_and_409(status):
+    session = FakeSession([FakeResponse(status)])
+    client = TraktClient("cid", "secret", session=session)
+
+    with pytest.raises(TraktDeviceDenied):
+        await client.poll_for_token("device-code")
+
+
+@pytest.mark.asyncio
+async def test_refresh_persists_tokens_via_update_trakt_oauth_tokens():
+    session = FakeSession([
+        FakeResponse(200, {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 7200,
+        })
+    ])
+    db = MagicMock()
+    client = TraktClient(
+        "cid",
+        "secret",
+        "old-access",
+        "old-refresh",
+        expires_at=int(time.time()) - 10,
+        session=session,
+        db=db,
+        link_id=1,
+        token_source="manual_oauth",
+    )
+
+    result = await client.refresh_access_token()
+
+    assert result["access_token"] == "new-access"
+    db.update_trakt_oauth_tokens.assert_called_once()
+    assert db.update_trakt_oauth_tokens.call_args.args[:3] == (1, "new-access", "new-refresh")
+    assert db.update_trakt_oauth_tokens.call_args.args[3] > int(time.time())
+    db.set_integration.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_for_token_persists_tokens_via_link_id():
+    """poll_for_token calls _apply_and_persist_tokens which persists when link_id is set."""
+    session = FakeSession([
+        FakeResponse(200, {
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "expires_in": 7200,
+        })
+    ])
+    db = MagicMock()
+    client = TraktClient(
+        "cid", "secret", session=session, db=db,
+        link_id=1, token_source="manual_oauth",
+    )
+
+    result = await client.poll_for_token("device-code")
+
+    assert result["access_token"] == "access"
+    db.update_trakt_oauth_tokens.assert_called_once_with(1, "access", "refresh", client.expires_at)
+
+
+@pytest.mark.asyncio
+async def test_get_user_settings_normalizes_trakt_user_payload():
+    session = FakeSession([
+        FakeResponse(200, {
+            "user": {
+                "username": "trakt_name",
+                "ids": {"slug": "trakt-slug", "uuid": "uuid-1"},
+            }
+        })
+    ])
+    client = TraktClient(
+        "cid",
+        "secret",
+        "access",
+        "refresh",
+        expires_at=int(time.time()) + 3600,
+        session=session,
+    )
+
+    result = await client.get_user_settings()
+
+    assert result["trakt_username"] == "trakt_name"
+    assert result["trakt_user_id"] == "uuid-1"
+    assert session.calls[0][1] == "https://api.trakt.tv/users/settings"
+
+
+@pytest.mark.asyncio
+async def test_recent_history_collapses_episodes_to_unique_parent_shows():
+    session = FakeSession([
+        FakeResponse(200, [
+            {"type": "episode", "show": {"title": "Severance", "year": 2022, "ids": {"tmdb": 95396}}},
+            {"type": "episode", "show": {"title": "Severance", "year": 2022, "ids": {"tmdb": 95396}}},
+            {"type": "movie", "movie": {"title": "Inception", "year": 2010, "ids": {"tmdb": 27205}}},
+        ])
+    ])
+    client = TraktClient("cid", "secret", "access", "refresh", expires_at=int(time.time()) + 3600, session=session)
+
+    result = await client.get_recent_items(limit=10)
+
+    assert result == [
+        {"tmdb_id": "95396", "media_type": "tv", "title": "Severance", "year": 2022, "watched_at": 0},
+        {"tmdb_id": "27205", "media_type": "movie", "title": "Inception", "year": 2010, "watched_at": 0},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_existing_content_uses_watched_movies_and_shows_tmdb_ids():
+    session = FakeSession([
+        FakeResponse(200, [{"movie": {"title": "Heat", "year": 1995, "ids": {"tmdb": 949}}}]),
+        FakeResponse(200, [{"show": {"title": "Dark", "year": 2017, "ids": {"tmdb": 70523}}}]),
+    ])
+    client = TraktClient("cid", "secret", "access", "refresh", expires_at=int(time.time()) + 3600, session=session)
+
+    await client.init_existing_content()
+
+    assert client.existing_content == {
+        "movie": [{"tmdb_id": "949", "title": "Heat", "year": 1995}],
+        "tv": [{"tmdb_id": "70523", "title": "Dark", "year": 2017}],
+    }
+
+
+def test_normalize_watched_items_includes_year():
+    payload = [
+        {"movie": {"title": "Heat", "year": 1995, "ids": {"tmdb": 949}}},
+        {"movie": {"title": "No Year", "ids": {"tmdb": 27205}}},
+    ]
+
+    normalized = TraktClient._normalize_watched_items(payload, "movie")
+
+    assert normalized == [
+        {"tmdb_id": "949", "title": "Heat", "year": 1995},
+        {"tmdb_id": "27205", "title": "No Year", "year": None},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_401_refreshes_once_and_retries():
+    session = FakeSession([
+        FakeResponse(401, {"error": "expired"}),
+        FakeResponse(200, {"access_token": "new-access", "refresh_token": "new-refresh", "expires_in": 7200}),
+        FakeResponse(200, []),
+    ])
+    db = MagicMock()
+    db.get_integration.return_value = {
+        "client_id": "cid",
+        "client_secret": "secret",
+        "access_token": "old",
+        "refresh_token": "refresh",
+    }
+    client = TraktClient("cid", "secret", "old", "refresh", expires_at=int(time.time()) + 3600, session=session, db=db)
+
+    result = await client.get_recent_items(limit=10)
+
+    assert result == []
+    assert session.calls[0][0] == "GET"
+    assert session.calls[1][0] == "POST"
+    assert session.calls[2][0] == "GET"
+    assert client.access_token == "new-access"
+    db.update_trakt_oauth_tokens.assert_not_called()
+    db.set_integration.assert_not_called()

--- a/api_service/test/test_trakt_media_user_routes.py
+++ b/api_service/test/test_trakt_media_user_routes.py
@@ -1,0 +1,174 @@
+from unittest.mock import MagicMock, patch
+
+from flask import Flask, g
+
+from api_service.blueprints.trakt.routes import trakt_bp
+from api_service.services.trakt.trakt_client import (
+    TraktDeviceDenied,
+    TraktDevicePending,
+)
+
+
+class FakeTraktClient:
+    instances = []
+
+    def __init__(
+        self,
+        client_id,
+        client_secret,
+        access_token="",
+        refresh_token="",
+        expires_at=None,
+        session=None,
+        db=None,
+        link_id=None,
+        token_source="manual_oauth",
+    ):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.db = db
+        self.link_id = link_id
+        self.token_source = token_source
+        FakeTraktClient.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def request_device_code(self):
+        return {"device_code": "dev-1", "user_code": "ABCD", "interval": 5, "expires_in": 600}
+
+    async def poll_for_token(self, device_code):
+        if device_code == "pending":
+            raise TraktDevicePending("Trakt device authorization pending")
+        if device_code == "denied":
+            raise TraktDeviceDenied("Trakt authorization was denied")
+        return {"access_token": "access", "refresh_token": "refresh", "expires_at": 12345}
+
+    async def get_user_settings(self):
+        return {"trakt_user_id": "trakt-user-1", "trakt_username": "trakt_name"}
+
+
+SELECTED = {"SELECTED_SERVICE": "jellyfin", "SELECTED_USERS": [{"id": "jf-1", "name": "alice"}]}
+
+
+def make_app(caller=None):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    caller_ref = {"user": caller or {"id": "1", "username": "admin", "role": "admin"}}
+
+    @app.before_request
+    def inject_caller():
+        g.current_user = caller_ref["user"]
+
+    app.register_blueprint(trakt_bp, url_prefix="/api/trakt")
+    return app, caller_ref
+
+
+def _patches(db):
+    return (
+        patch("api_service.blueprints.trakt.routes.DatabaseManager", return_value=db),
+        patch("api_service.blueprints.trakt.routes.TraktClient", FakeTraktClient),
+        patch("api_service.blueprints.trakt.routes.load_env_vars", return_value=SELECTED),
+        patch(
+            "api_service.blueprints.trakt.routes._resolve_trakt_credentials",
+            return_value=("cid", "secret", False),
+        ),
+    )
+
+
+def test_list_media_users_merges_selected_users_with_link_status():
+    app, _ = make_app()
+    db = MagicMock()
+    db.get_media_user_identity.return_value = {"id": 1, "provider": "jellyfin", "external_user_id": "jf-1"}
+    db.get_trakt_account_link.return_value = {
+        "id": 5, "media_user_identity_id": 1, "connected": True, "trakt_username": "alice_t",
+    }
+    db.get_enabled_trakt_sources.return_value = [
+        {"source_type": "watched_history", "use_as_seed": True, "use_as_exclusion": True},
+    ]
+    p1, p2, p3, p4 = _patches(db)
+    with p1, p2, p3, p4:
+        resp = app.test_client().get("/api/trakt/media-users")
+    assert resp.status_code == 200
+    rows = resp.get_json()["media_users"]
+    assert rows[0]["external_user_id"] == "jf-1"
+    assert rows[0]["external_username"] == "alice"
+    assert rows[0]["trakt"]["connected"] is True
+    db.get_trakt_account_link.assert_called_once_with(1)
+
+
+def test_device_token_creates_identity_link_tokens_and_source():
+    app, _ = make_app()
+    db = MagicMock()
+    db.upsert_media_user_identity.return_value = {"id": 1}
+    db.upsert_trakt_account_link.return_value = 5
+    p1, p2, p3, p4 = _patches(db)
+    with p1, p2, p3, p4:
+        resp = app.test_client().post(
+            "/api/trakt/media-users/jellyfin/jf-1/device/token",
+            json={"device_code": "dev-1"},
+        )
+    assert resp.status_code == 200
+    # Step 1: identity (the (provider, external_user_id) anchor)
+    db.upsert_media_user_identity.assert_called_once_with("jellyfin", "jf-1", "alice")
+    # Step 2: link keyed by the identity
+    db.upsert_trakt_account_link.assert_called_once()
+    assert db.upsert_trakt_account_link.call_args.kwargs["media_user_identity_id"] == 1
+    assert db.upsert_trakt_account_link.call_args.kwargs["trakt_username"] == "trakt_name"
+    assert db.upsert_trakt_account_link.call_args.kwargs["token_source"] == "manual_oauth"
+    # Step 3: tokens
+    db.upsert_trakt_oauth_tokens.assert_called_once()
+    assert db.upsert_trakt_oauth_tokens.call_args.kwargs["link_id"] == 5
+    assert db.upsert_trakt_oauth_tokens.call_args.kwargs["access_token"] == "access"
+    # Step 4: source keyed by the identity
+    db.upsert_trakt_source.assert_called_once_with(
+        media_user_identity_id=1, source_type="watched_history",
+        source_key="watched_history", enabled=True, use_as_seed=True, use_as_exclusion=True,
+    )
+
+
+def test_device_token_pending_returns_202():
+    app, _ = make_app()
+    db = MagicMock()
+    p1, p2, p3, p4 = _patches(db)
+    with p1, p2, p3, p4:
+        resp = app.test_client().post(
+            "/api/trakt/media-users/jellyfin/jf-1/device/token",
+            json={"device_code": "pending"},
+        )
+    assert resp.status_code == 202
+    db.upsert_media_user_identity.assert_not_called()
+
+
+def test_unknown_media_user_returns_404():
+    app, _ = make_app()
+    db = MagicMock()
+    p1, p2, p3, p4 = _patches(db)
+    with p1, p2, p3, p4:
+        resp = app.test_client().post(
+            "/api/trakt/media-users/jellyfin/ghost/device/code", json={}
+        )
+    assert resp.status_code == 404
+
+
+def test_wrong_provider_returns_404():
+    app, _ = make_app()
+    db = MagicMock()
+    p1, p2, p3, p4 = _patches(db)
+    with p1, p2, p3, p4:
+        resp = app.test_client().delete("/api/trakt/media-users/plex/jf-1")
+    assert resp.status_code == 404
+
+
+def test_delete_unlinks_trakt_account():
+    app, _ = make_app()
+    db = MagicMock()
+    db.get_media_user_identity.return_value = {"id": 1}
+    p1, p2, p3, p4 = _patches(db)
+    with p1, p2, p3, p4:
+        resp = app.test_client().delete("/api/trakt/media-users/jellyfin/jf-1")
+    assert resp.status_code == 200
+    db.unlink_trakt_account.assert_called_once_with(1)

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
     "@vue/cli-plugin-babel": "^5.0.9",
+    "@vue/cli-plugin-eslint": "~5.0.8",
     "@vue/cli-service": "^5.0.8",
     "@vue/compiler-sfc": "^3.5.13",
     "@vue/tsconfig": "^0.9.0",

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -140,6 +140,22 @@ export const aiSearchStatus = () => {
     return axios.get('/api/ai-search/status');
 };
 
+// Trakt OAuth device flow (admin, media-user scoped). App credentials are admin
+// settings; account tokens are stored per media-server user (provider + id).
+export const listTraktMediaUsers = () => axios.get('/api/trakt/media-users');
+
+export const startMediaUserTraktDeviceCode = (provider, externalUserId, credentials = {}) =>
+    axios.post(`/api/trakt/media-users/${provider}/${encodeURIComponent(externalUserId)}/device/code`, credentials);
+
+export const pollMediaUserTraktDeviceToken = (provider, externalUserId, deviceCode, credentials = {}) =>
+    axios.post(`/api/trakt/media-users/${provider}/${encodeURIComponent(externalUserId)}/device/token`, { ...credentials, device_code: deviceCode });
+
+export const unlinkMediaUserTrakt = (provider, externalUserId) =>
+    axios.delete(`/api/trakt/media-users/${provider}/${encodeURIComponent(externalUserId)}`);
+
+export const updateTraktSource = (provider, externalUserId, payload) =>
+    axios.put(`/api/trakt/sources/${provider}/${encodeURIComponent(externalUserId)}`, payload);
+
 
 // Cleanup automation
 export const getCleanupSettings = () => axios.get('/api/cleanup/settings');

--- a/client/src/components/ConfigWizard.vue
+++ b/client/src/components/ConfigWizard.vue
@@ -330,6 +330,14 @@ export default {
           optional: false,
         },
         {
+          id: 'trakt',
+          label: 'Trakt',
+          description: 'Augment recommendations with your Trakt watch history.',
+          component: SettingsServices,
+          wizardSection: 'trakt',
+          optional: true,
+        },
+        {
           id: 'scheduling',
           label: 'Schedule',
           description: 'Set how often SuggestArr automatically finds and requests content for you.',
@@ -378,7 +386,9 @@ export default {
       const step = currentStep.value;
       if (step.id === 'service') {
         if (!config.value.SELECTED_SERVICE) return 'Select a media service above to continue.';
-        if (!stepValidity.value['media-server']) return 'Connect your media server to continue.';
+        if (!stepValidity.value['media-server']) {
+            return 'Connect your media server to continue.';
+          }
       }
       if (step.id === 'tmdb') return 'Test your TMDB connection above to continue.';
       if (step.id === 'seer') return 'Test your Seer connection above to continue.';
@@ -527,10 +537,9 @@ export default {
           stepValidity.value['media-server'] = true;
         } else if ((svc === 'jellyfin' || svc === 'emby') && cfg.JELLYFIN_API_URL && cfg.JELLYFIN_TOKEN) {
           stepValidity.value['media-server'] = true;
-        } else if (svc === 'trakt' && cfg.TRAKT_ACCESS_TOKEN) {
-          stepValidity.value['media-server'] = true;
         }
       }
+      if (cfg.TRAKT_CLIENT_ID && cfg.TRAKT_CLIENT_SECRET) stepValidity.value.trakt = true;
     }
 
     async function handleFileImport(event) {

--- a/client/src/components/DashboardPage.vue
+++ b/client/src/components/DashboardPage.vue
@@ -344,6 +344,7 @@ import AiSearchPage from './settings/AiSearchPage.vue';
 import LogsComponent from './LogsComponent.vue';
 import UserManagement from './settings/UserManagement.vue';
 import UserProfile from './settings/UserProfile.vue';
+import TraktMediaUsers from './settings/TraktMediaUsers.vue';
 import { exportConfig, importConfig } from '@/api/api';
 
 const TOUR_STORAGE_KEY = 'suggestarr_tour_done';
@@ -362,6 +363,7 @@ export default {
     LogsComponent,
     UserManagement,
     UserProfile,
+    TraktMediaUsers,
   },
   setup() {
     const { bg1Url, bg2Url, activeBg, isTransitioning, startDefaultImageRotation, startBackgroundImageRotation, stopBackgroundImageRotation } = useBackgroundImage();
@@ -418,6 +420,7 @@ export default {
         { id: 'database',  name: 'Database',  icon: 'fas fa-database',     tourId: 'tab-database', adminOnly: true },
         { id: 'advanced',  name: 'Advanced',  icon: 'fas fa-sliders-h',   tourId: 'tab-advanced', adminOnly: true },
         { id: 'users',     name: 'Users',      icon: 'fas fa-users',       adminOnly: true },
+        { id: 'trakt',     name: 'Trakt',      icon: 'fas fa-tv',          adminOnly: true },
         { id: 'profile',   name: 'Profile',    icon: 'fas fa-user-circle', nonAdminOnly: true },
         { id: 'logs',      name: 'Logs',       icon: 'fas fa-file-alt',    tourId: 'tab-logs', adminOnly: true },
       ],
@@ -523,6 +526,7 @@ export default {
         logs: 'LogsComponent',
         ai_search: 'AiSearchPage',
         users: 'UserManagement',
+        trakt: 'TraktMediaUsers',
         profile: 'UserProfile',
       };
       return componentMap[this.activeTab] ?? null;
@@ -948,6 +952,7 @@ export default {
       
       if (service === 'plex' && this.config.PLEX_TOKEN) return 'status-connected';
       if ((service === 'jellyfin' || service === 'emby') && this.config.JELLYFIN_TOKEN) return 'status-connected';
+      if (service === 'trakt' && this.config.TRAKT_CLIENT_ID && this.config.TRAKT_CLIENT_SECRET) return 'status-connected';
       
       return 'status-warning';
     },
@@ -956,7 +961,8 @@ export default {
       const icons = {
         plex: 'fas fa-play-circle',
         jellyfin: 'fas fa-server',
-        emby: 'fas fa-server'
+        emby: 'fas fa-server',
+        trakt: 'fas fa-tv',
       };
       return icons[this.config.SELECTED_SERVICE] || 'fas fa-question-circle';
     },

--- a/client/src/components/settings/SettingsServices.vue
+++ b/client/src/components/settings/SettingsServices.vue
@@ -351,6 +351,52 @@
         </div>
       </div>
 
+      <!-- Trakt -->
+      <div v-if="showSection('trakt')" :class="wizardMode ? '' : 'service-card'">
+        <div v-if="!wizardMode" class="service-header">
+          <h3><i class="fas fa-history"></i> Trakt</h3>
+          <span class="status-badge" :class="getTraktStatus">
+            <span class="status-dot"></span>
+            {{ getTraktStatusText }}
+          </span>
+        </div>
+
+        <div class="form-group">
+          <label for="traktClientId">Client ID</label>
+          <input
+            id="traktClientId"
+            v-model="localConfig.TRAKT_CLIENT_ID"
+            type="text"
+            placeholder="Enter your Trakt Client ID"
+            class="form-control"
+            :disabled="isLoading"
+          />
+        </div>
+        <div class="form-group">
+          <label for="traktClientSecret">Client Secret</label>
+          <div class="input-group">
+            <input
+              id="traktClientSecret"
+              v-model="localConfig.TRAKT_CLIENT_SECRET"
+              :type="showTraktClientSecret ? 'text' : 'password'"
+              placeholder="Enter your Trakt Client Secret"
+              class="form-control"
+              :disabled="isLoading"
+            />
+            <button @click="showTraktClientSecret = !showTraktClientSecret" type="button" class="btn btn-outline btn-sm" :disabled="isLoading">
+              <i :class="showTraktClientSecret ? 'fas fa-eye-slash' : 'fas fa-eye'"></i>
+            </button>
+          </div>
+          <small class="form-help">
+            Create an app at <a href="https://trakt.tv/oauth/applications" target="_blank" rel="noopener noreferrer" class="link">Trakt OAuth Applications</a>.
+          </small>
+        </div>
+        <div class="oauth-success" v-if="isTraktAppConfigured">
+          <i class="fas fa-check-circle"></i>
+          Trakt app credentials configured. Link Trakt accounts from Dashboard &gt; Trakt.
+        </div>
+      </div>
+
       <!-- Seer  -->
       <div v-if="showSection('seer')" :class="wizardMode ? '' : 'service-card'">
         <div v-if="!wizardMode" class="service-header">
@@ -587,6 +633,7 @@ export default {
       showPlexToken: false,
       showJellyfinToken: false,
       showSeerToken: false,
+      showTraktClientSecret: false,
       // Wizard-mode self-contained TMDB test state
       wizardTmdbTesting: false,
       wizardTmdbConnected: false,
@@ -655,6 +702,9 @@ export default {
     },
     mediaServerConnected() {
       return this.plexConnected || this.jellyfinConnected;
+    },
+    isTraktAppConfigured() {
+      return !!(this.localConfig.TRAKT_CLIENT_ID && this.localConfig.TRAKT_CLIENT_SECRET);
     },
     // Unified accessors for current service's libraries/users
     currentLibraries() {
@@ -754,6 +804,16 @@ export default {
         ? 'Not Tested'
         : 'Not Set';
     },
+    getTraktStatus() {
+      if (this.isTraktAppConfigured) return 'status-connected';
+      if (this.localConfig.TRAKT_CLIENT_ID || this.localConfig.TRAKT_CLIENT_SECRET) return 'status-warning';
+      return 'status-disconnected';
+    },
+    getTraktStatusText() {
+      if (this.isTraktAppConfigured) return 'Configured';
+      if (this.localConfig.TRAKT_CLIENT_ID || this.localConfig.TRAKT_CLIENT_SECRET) return 'Incomplete';
+      return 'Not Set';
+    },
     seerUserOptions() {
       return this.seerUsers.map(user => ({
         label: `${user.name}${user.email ? ` (${user.email})` : ''}`,
@@ -837,6 +897,14 @@ export default {
     },
     plexConnected(val) {
       if (this.wizardMode && this.wizardSection === 'media-server') {
+        this.$emit('validation-changed', val);
+      }
+    },
+    isTraktAppConfigured(val) {
+      if (
+        this.wizardMode
+        && this.wizardSection === 'trakt'
+      ) {
         this.$emit('validation-changed', val);
       }
     },
@@ -1379,6 +1447,8 @@ export default {
           TMDB_API_KEY: this._secretValue('TMDB_API_KEY'),
           OMDB_API_KEY: this._secretValue('OMDB_API_KEY') || '',
           SELECTED_SERVICE: this.localConfig.SELECTED_SERVICE,
+          TRAKT_CLIENT_ID: this.localConfig.TRAKT_CLIENT_ID || '',
+          TRAKT_CLIENT_SECRET: this._secretValue('TRAKT_CLIENT_SECRET') || '',
         };
         if (this.localConfig.SELECTED_SERVICE === 'plex') {
           Object.assign(dataToSave, {
@@ -1414,6 +1484,7 @@ export default {
       const defaults = {
         TMDB_API_KEY: '', OMDB_API_KEY: '', SELECTED_SERVICE: '', PLEX_TOKEN: '', PLEX_API_URL: '', PLEX_LIBRARIES: [],
         JELLYFIN_API_URL: '', JELLYFIN_TOKEN: '', JELLYFIN_LIBRARIES: [],
+        TRAKT_CLIENT_ID: '', TRAKT_CLIENT_SECRET: '',
         SEER_API_URL: '', SEER_TOKEN: '', SEER_USER_NAME: null, SEER_USER_PSW: null,
         SEER_SESSION_TOKEN: null, SEER_ANIME_PROFILE_CONFIG: {}, SEER_REQUEST_DELAY: 2, SELECTED_USERS: [],
       };

--- a/client/src/components/settings/TraktMediaUsers.vue
+++ b/client/src/components/settings/TraktMediaUsers.vue
@@ -70,7 +70,7 @@
           <i class="fas fa-key"></i>
           Enter <strong>{{ traktUserCode }}</strong> at
           <a :href="traktVerificationUrl" target="_blank" rel="noopener noreferrer" class="link">{{ traktVerificationUrl }}</a>
-          <p v-if="traktPopupBlocked" class="list-empty" style="margin-top: 0.75rem;">
+          <p v-if="traktPopupBlocked" class="list-empty popup-blocked-hint">
             <i class="fas fa-exclamation-circle"></i>
             Pop-up blocked. Open the link above manually to authorize.
           </p>
@@ -424,6 +424,10 @@ export default {
   display: flex;
   justify-content: flex-end;
   gap: 0.5rem;
+}
+
+.popup-blocked-hint {
+  margin-top: 0.75rem;
 }
 
 @media (max-width: 768px) {

--- a/client/src/components/settings/TraktMediaUsers.vue
+++ b/client/src/components/settings/TraktMediaUsers.vue
@@ -1,0 +1,442 @@
+<template>
+  <div class="settings-section">
+    <div class="settings-group">
+      <h2 class="settings-group-title">
+        <i class="fas fa-tv"></i>
+        Trakt — Media Users
+      </h2>
+      <p class="settings-group-subtitle">
+        Link a Trakt account to each media-server user. Linked accounts add recent
+        watches as recommendation seeds and contribute watched history to the
+        skip-watched set during that user's run.
+      </p>
+
+      <!-- App credentials not configured -->
+      <div v-if="!traktAppConfigured" class="list-empty">
+        <i class="fas fa-info-circle"></i>
+        Trakt app credentials are not configured. Set the Trakt Client ID and Secret
+        under Services before linking accounts.
+      </div>
+
+      <div v-else>
+        <div v-if="loadError" class="error-banner" role="alert">
+          <i class="fas fa-exclamation-triangle"></i>
+          {{ loadError }}
+        </div>
+
+        <div v-if="isLoadingUsers" class="list-empty">
+          <i class="fas fa-spinner fa-spin"></i> Loading media users…
+        </div>
+
+        <div v-else-if="mediaUsers.length === 0" class="list-empty">
+          <i class="fas fa-users-slash"></i>
+          No media users selected. Choose users in the Services configuration first.
+        </div>
+
+        <ul v-else class="user-list">
+          <li v-for="user in mediaUsers" :key="rowKey(user)" class="user-row">
+            <div class="user-info">
+              <i class="fas fa-user"></i>
+              <div class="user-text">
+                <span class="user-name">{{ user.external_username || user.external_user_id }}</span>
+                <span class="user-meta">{{ statusLabel(user) }}</span>
+              </div>
+            </div>
+
+            <div class="user-actions">
+              <button
+                v-if="user.trakt && user.trakt.connected"
+                class="btn btn-danger btn-sm icon-btn"
+                :disabled="isUnlinking[rowKey(user)]"
+                title="Unlink Trakt"
+                @click="unlinkUser(user)"
+              >
+                <i :class="isUnlinking[rowKey(user)] ? 'fas fa-spinner fa-spin' : 'fas fa-unlink'"></i>
+              </button>
+              <button
+                class="btn btn-outline btn-sm"
+                :disabled="isBusy(user)"
+                @click="connectUser(user)"
+              >
+                <i :class="isBusy(user) ? 'fas fa-spinner fa-spin' : 'fas fa-link'"></i>
+                {{ connectLabel(user) }}
+              </button>
+            </div>
+          </li>
+        </ul>
+
+        <!-- Active device-code prompt -->
+        <div v-if="traktUserCode" class="oauth-success">
+          <i class="fas fa-key"></i>
+          Enter <strong>{{ traktUserCode }}</strong> at
+          <a :href="traktVerificationUrl" target="_blank" rel="noopener noreferrer" class="link">{{ traktVerificationUrl }}</a>
+          <p v-if="traktPopupBlocked" class="list-empty" style="margin-top: 0.75rem;">
+            <i class="fas fa-exclamation-circle"></i>
+            Pop-up blocked. Open the link above manually to authorize.
+          </p>
+        </div>
+        <div v-if="actionError" class="error-banner" role="alert">
+          <i class="fas fa-exclamation-triangle"></i>
+          {{ actionError }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Confirm unlink dialog -->
+    <teleport to="body">
+      <div v-if="showUnlinkConfirm" class="modal-overlay" @click.self="cancelUnlink">
+        <div class="modal-box">
+          <h3>Unlink Trakt Account</h3>
+          <p>
+            Are you sure you want to unlink the Trakt account for
+            <strong>{{ unlinkTargetLabel }}</strong>? This will remove their seed
+            and watched-history data from recommendation runs.
+          </p>
+          <div class="modal-actions">
+            <button class="btn btn-outline" @click="cancelUnlink">Cancel</button>
+            <button class="btn btn-danger" @click="confirmUnlink" :disabled="isUnlinking[unlinkTargetKey]">
+              <i v-if="isUnlinking[unlinkTargetKey]" class="fas fa-spinner fa-spin"></i>
+              Unlink
+            </button>
+          </div>
+        </div>
+      </div>
+    </teleport>
+  </div>
+</template>
+
+<script>
+import {
+  listTraktMediaUsers,
+  startMediaUserTraktDeviceCode,
+  pollMediaUserTraktDeviceToken,
+  unlinkMediaUserTrakt,
+} from '@/api/api';
+import traktDevicePolling from './mixins/traktDevicePolling';
+
+export default {
+  name: 'TraktMediaUsers',
+  mixins: [traktDevicePolling],
+  props: {
+    config: Object,
+  },
+  data() {
+    return {
+      mediaUsers: [],
+      isLoadingUsers: false,
+      loadError: null,
+      actionError: null,
+      isConnecting: {},
+      isUnlinking: {},
+      activeTarget: null,
+      showUnlinkConfirm: false,
+      unlinkTargetKey: '',
+      unlinkTargetLabel: '',
+      traktPopupBlocked: false,
+    };
+  },
+  computed: {
+    traktAppConfigured() {
+      return !!(this.config?.TRAKT_CLIENT_ID && this.config?.TRAKT_CLIENT_SECRET);
+    },
+  },
+  async mounted() {
+    if (this.traktAppConfigured) {
+      await this.loadMediaUsers();
+    }
+  },
+  methods: {
+    rowKey(user) {
+      return `${user.provider}:${user.external_user_id}`;
+    },
+    isBusy(user) {
+      return !!this.isConnecting[this.rowKey(user)] || (this.isPollingTrakt && this.activeTarget === this.rowKey(user));
+    },
+    connectLabel(user) {
+      if (this.isPollingTrakt && this.activeTarget === this.rowKey(user)) return 'Waiting for Trakt…';
+      return user.trakt && user.trakt.connected ? 'Re-link' : 'Link Trakt';
+    },
+    statusLabel(user) {
+      const t = user.trakt || {};
+      if (t.connected) return `Linked as ${t.trakt_username || 'Trakt user'}`;
+      if (t.status === 'expired' || t.status === 'error' || t.status === 'revoked') {
+        return t.last_error ? `Needs re-link — ${t.last_error}` : 'Needs re-link';
+      }
+      return 'Not linked';
+    },
+    async loadMediaUsers() {
+      this.isLoadingUsers = true;
+      this.loadError = null;
+      try {
+        const res = await listTraktMediaUsers();
+        this.mediaUsers = res.data?.media_users || [];
+      } catch (err) {
+        this.loadError = err.response?.data?.message || 'Failed to load media users';
+        this.mediaUsers = [];
+      } finally {
+        this.isLoadingUsers = false;
+      }
+    },
+    async connectUser(user) {
+      const key = this.rowKey(user);
+      this.actionError = null;
+      this.activeTarget = key;
+      this.isConnecting = { ...this.isConnecting, [key]: true };
+      this.traktPopupBlocked = false;
+      try {
+        const started = await this.startTraktPolling({
+          requestCode: () => startMediaUserTraktDeviceCode(user.provider, user.external_user_id),
+          pollToken: (deviceCode) => pollMediaUserTraktDeviceToken(user.provider, user.external_user_id, deviceCode),
+          onConnected: async (data) => {
+            await this.loadMediaUsers();
+            this.$toast.success(`Trakt linked for ${user.external_username || user.external_user_id} as ${data.trakt_username || 'Trakt user'}`);
+          },
+          setError: (message) => { this.actionError = message; },
+          onPopupBlocked: () => { this.traktPopupBlocked = true; },
+          windowName: 'trakt-oauth',
+        });
+        if (!started) {
+          this.traktPopupBlocked = true;
+        }
+      } finally {
+        this.isConnecting = { ...this.isConnecting, [key]: false };
+      }
+    },
+    unlinkUser(user) {
+      this.unlinkTargetKey = this.rowKey(user);
+      this.unlinkTargetLabel = user.external_username || user.external_user_id;
+      this.showUnlinkConfirm = true;
+    },
+    cancelUnlink() {
+      this.showUnlinkConfirm = false;
+      this.unlinkTargetKey = '';
+      this.unlinkTargetLabel = '';
+    },
+    async confirmUnlink() {
+      const key = this.unlinkTargetKey;
+      const label = this.unlinkTargetLabel;
+      this.isUnlinking = { ...this.isUnlinking, [key]: true };
+      try {
+        const [provider, externalUserId] = key.split(':');
+        await unlinkMediaUserTrakt(provider, externalUserId);
+        await this.loadMediaUsers();
+        this.$toast.success(`Trakt unlinked for ${label}`);
+      } catch (err) {
+        this.$toast.error(err.response?.data?.message || 'Failed to unlink Trakt');
+      } finally {
+        this.isUnlinking = { ...this.isUnlinking, [key]: false };
+        this.cancelUnlink();
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+/* Shared with UserManagement / SettingsServices */
+.settings-section {
+  padding-bottom: 1.5rem;
+}
+
+.settings-group {
+  padding: 1.5rem 2rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid var(--surface-glass-light);
+  border-radius: var(--border-radius);
+  background: var(--surface-glass-subtle);
+}
+
+.settings-group-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0 0 0.5rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.settings-group-title i {
+  opacity: 0.7;
+}
+
+.settings-group-subtitle {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin: 0 0 1.25rem 0;
+  line-height: 1.5;
+}
+
+.list-empty {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin: 0;
+  padding: 0.75rem;
+  background: var(--surface-glass-subtle);
+  border-radius: var(--border-radius-sm);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.user-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.user-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--surface-glass-subtle);
+  border: 1px solid var(--surface-glass-light);
+  border-radius: var(--border-radius-sm);
+  transition: border-color 0.15s ease;
+}
+
+.user-row:hover {
+  border-color: var(--surface-interactive);
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.user-info > i {
+  opacity: 0.6;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.user-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.user-name {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.user-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.user-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.error-banner {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #ef4444;
+  padding: 0.75rem 1rem;
+  border-radius: var(--border-radius-sm);
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.oauth-success {
+  padding: 0.75rem 1rem;
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: var(--border-radius-sm);
+  color: #10b981;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  line-height: 1.6;
+  word-break: break-all;
+}
+
+.oauth-success i {
+  margin-right: 0.35rem;
+}
+
+.link {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+/* Confirm dialog */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.modal-box {
+  background: var(--surface-primary);
+  border: 1px solid var(--surface-glass-light);
+  border-radius: var(--border-radius);
+  padding: 1.5rem;
+  max-width: 420px;
+  width: 90%;
+}
+
+.modal-box h3 {
+  margin: 0 0 0.75rem 0;
+  color: var(--color-text-primary);
+  font-size: 1.05rem;
+}
+
+.modal-box p {
+  margin: 0 0 1.25rem 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .settings-group {
+    padding: 1rem;
+  }
+  .user-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .user-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/client/src/components/settings/UserManagement.vue
+++ b/client/src/components/settings/UserManagement.vue
@@ -91,7 +91,7 @@
             </button>
 
             <button
-              :disabled="!!isSaving[user.id] || !selectedService"
+              :disabled="!!isSaving[user.id] || !supportsUserLinks"
               class="btn btn-outline btn-sm icon-btn"
               title="Assign media account"
               @click="openMediaLinkModal(user)"
@@ -519,6 +519,9 @@ export default {
     selectedService() {
       return (this.config?.SELECTED_SERVICE || '').toLowerCase();
     },
+    supportsUserLinks() {
+      return ['jellyfin', 'emby', 'plex'].includes(this.selectedService);
+    },
     providerLabel() {
       const labels = { plex: 'Plex', jellyfin: 'Jellyfin', emby: 'Emby' };
       return labels[this.selectedService] || 'media';
@@ -707,6 +710,7 @@ export default {
     },
 
     async openMediaLinkModal(user) {
+      if (!this.supportsUserLinks) return;
       this.mediaLinkTarget = user;
       this.mediaUsers = [];
       this.selectedMediaUserId = '';
@@ -716,7 +720,7 @@ export default {
     },
 
     async loadMediaUsers() {
-      if (!['plex', 'jellyfin', 'emby'].includes(this.selectedService)) {
+      if (!this.supportsUserLinks) {
         this.mediaLinkError = 'No supported media service configured';
         return;
       }

--- a/client/src/components/settings/UserProfile.vue
+++ b/client/src/components/settings/UserProfile.vue
@@ -223,7 +223,7 @@
       </div>
 
       <!-- No linkable service configured -->
-      <div v-else-if="hasProviderContext" class="settings-group">
+      <div v-if="!isLinkableService && hasProviderContext" class="settings-group">
         <h3>
           <i class="fas fa-plug"></i>
           Media Server
@@ -307,6 +307,7 @@ export default {
       isLinking: false,
       isUnlinking: false,
       linkError: null,
+
     };
   },
 

--- a/client/src/components/settings/jobs/RecommendationFilters.vue
+++ b/client/src/components/settings/jobs/RecommendationFilters.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="recommendation-filters">
     <!-- User Selection Mode -->
-    <div class="form-group">
+    <div v-if="!isTraktSource" class="form-group">
       <label>Monitor Users</label>
       <div class="user-mode-selector">
         <button
@@ -26,9 +26,13 @@
     </div>
 
     <!-- User Selection (when specific mode) -->
-    <div v-if="userMode === 'specific'" class="form-group">
+    <div v-if="!isTraktSource && userMode === 'specific'" class="form-group">
       <label>Select Users</label>
-      <div class="users-list" v-if="availableUsers.length > 0">
+      <div v-if="usersUnavailable" class="no-users">
+        <i class="fas fa-lock"></i>
+        <span>User selection is only available to administrators.</span>
+      </div>
+      <div class="users-list" v-else-if="availableUsers.length > 0">
         <div
           v-for="user in availableUsers"
           :key="user.id"
@@ -50,6 +54,14 @@
       <div v-else class="no-users">
         <i class="fas fa-user-slash"></i>
         <span>No users found. Configure SELECTED_USERS in settings.</span>
+      </div>
+    </div>
+
+    <div v-if="isTraktSource" class="form-group">
+      <label>Trakt Account</label>
+      <div class="no-users">
+        <i class="fas fa-tv"></i>
+        <span>This job uses the owner's linked Trakt account.</span>
       </div>
     </div>
 
@@ -189,6 +201,42 @@
             </BaseCheckbox>
           </div>
           <small class="toggle-help">Respect Seer's discovery settings for requests</small>
+
+          <div class="toggle-item">
+            <BaseCheckbox v-model="localFilters.use_trakt_as_seed" :disabled="!traktUsable">
+              <span class="toggle-label-modal" :class="{ 'toggle-disabled': !traktUsable }">
+                <i class="fas fa-seedling"></i>
+                Use Trakt as Seed
+              </span>
+            </BaseCheckbox>
+          </div>
+          <small v-if="!traktConfigured" class="toggle-help toggle-help--warn">
+            <i class="fas fa-exclamation-triangle"></i>
+            Trakt not configured — set Client ID / Secret in Services
+          </small>
+          <small v-else-if="!traktUsable" class="toggle-help toggle-help--warn">
+            <i class="fas fa-exclamation-triangle"></i>
+            No linked Trakt accounts — link accounts in Dashboard &gt; Trakt
+          </small>
+          <small v-else class="toggle-help">Use linked Trakt watch history to find similar content</small>
+
+          <div class="toggle-item">
+            <BaseCheckbox v-model="localFilters.use_trakt_as_exclusion" :disabled="!traktUsable">
+              <span class="toggle-label-modal" :class="{ 'toggle-disabled': !traktUsable }">
+                <i class="fas fa-ban"></i>
+                Exclude Trakt Watched
+              </span>
+            </BaseCheckbox>
+          </div>
+          <small v-if="!traktConfigured" class="toggle-help toggle-help--warn">
+            <i class="fas fa-exclamation-triangle"></i>
+            Trakt not configured — set Client ID / Secret in Services
+          </small>
+          <small v-else-if="!traktUsable" class="toggle-help toggle-help--warn">
+            <i class="fas fa-exclamation-triangle"></i>
+            No linked Trakt accounts — link accounts in Dashboard &gt; Trakt
+          </small>
+          <small v-else class="toggle-help">Skip content already watched on Trakt</small>
         </div>
       </div>
     </template>
@@ -198,6 +246,7 @@
 <script>
 import axios from 'axios';
 import { waitForAuthReady } from '@/composables/useAuth';
+import { listTraktMediaUsers } from '@/api/api';
 import BaseCheckbox from '@/components/common/BaseCheckbox.vue';
 
 export default {
@@ -221,6 +270,7 @@ export default {
   data() {
     return {
       availableUsers: [],
+      usersUnavailable: false,
       isLoading: false,
       localFilters: {
         use_llm: false,
@@ -230,19 +280,38 @@ export default {
         search_size: 20,
         exclude_downloaded: true,
         exclude_requested: true,
-        honor_seer_discovery: false
+        honor_seer_discovery: false,
+        use_trakt_as_seed: true,
+        use_trakt_as_exclusion: true
       },
       isUpdatingFromParent: false,
-      localUserMode: 'all'
+      localUserMode: 'all',
+      selectedService: '',
+      traktConfigured: false,
+      traktMediaUsers: [],
     };
   },
   computed: {
+    isTraktSource() {
+      return this.selectedService === 'trakt';
+    },
     userMode() {
       return this.localUserMode;
     },
     maxResults() {
       return this.modelValue.max_results || 20;
-    }
+    },
+    traktUsable() {
+      if (!this.traktConfigured || !this.traktMediaUsers.length) return false;
+      if (this.userMode === 'all') {
+        return this.traktMediaUsers.some(u => u.trakt?.connected);
+      }
+      const selectedIds = this.modelValue.user_ids || [];
+      if (!selectedIds.length) return false;
+      return this.traktMediaUsers.some(
+        u => selectedIds.includes(u.external_user_id) && u.trakt?.connected
+      );
+    },
   },
   watch: {
     modelValue: {
@@ -257,14 +326,16 @@ export default {
             search_size: newVal.filters.search_size ?? 20,
             exclude_downloaded: newVal.filters.exclude_downloaded ?? true,
             exclude_requested: newVal.filters.exclude_requested ?? true,
-            honor_seer_discovery: newVal.filters.honor_seer_discovery ?? false
+            honor_seer_discovery: newVal.filters.honor_seer_discovery ?? false,
+            use_trakt_as_seed: newVal.filters.use_trakt_as_seed ?? true,
+            use_trakt_as_exclusion: newVal.filters.use_trakt_as_exclusion ?? true
           };
           this.$nextTick(() => {
             this.isUpdatingFromParent = false;
           });
         }
         // Initialize user mode based on user_ids
-        if (newVal.user_ids && newVal.user_ids.length > 0) {
+        if (!this.isTraktSource && newVal.user_ids && newVal.user_ids.length > 0) {
           this.localUserMode = 'specific';
         }
       },
@@ -290,16 +361,55 @@ export default {
       try {
         // Ensure auth is ready before making the protected API call
         await waitForAuthReady();
-        // Try to get users from the config
-        const response = await axios.get('/api/config/fetch');
-        if (response.data && response.data.SELECTED_USERS) {
-          const users = response.data.SELECTED_USERS;
-          this.availableUsers = users.map(u => {
-            if (typeof u === 'string') {
-              return { id: u, name: u };
-            }
-            return { id: u.id, name: u.name || u.id };
+        const statusResponse = await axios.get('/api/config/status');
+        this.selectedService = String(statusResponse.data?.selected_service || '').toLowerCase();
+        this.traktConfigured = statusResponse.data?.trakt_app_configured === true;
+        if (this.traktConfigured) {
+          try {
+            const traktRes = await listTraktMediaUsers();
+            this.traktMediaUsers = traktRes.data?.media_users || [];
+          } catch {
+            this.traktMediaUsers = [];
+          }
+        } else {
+          this.traktMediaUsers = [];
+        }
+        if (this.isTraktSource && this.modelValue.user_ids?.length) {
+          this.$emit('update:modelValue', {
+            ...this.modelValue,
+            user_ids: []
           });
+        }
+        if (this.isTraktSource) {
+          return;
+        }
+
+        // Admin users can still populate configured media users when available.
+        // /api/config/fetch is admin-only; non-admins receive a 403, which we
+        // handle gracefully instead of treating it as a hard error.
+        this.usersUnavailable = false;
+        try {
+          const response = await axios.get('/api/config/fetch');
+          if (response.data?.SELECTED_SERVICE) {
+            this.selectedService = String(response.data.SELECTED_SERVICE || '').toLowerCase();
+          }
+          if (response.data && response.data.SELECTED_USERS) {
+            const users = response.data.SELECTED_USERS;
+            this.availableUsers = users.map(u => {
+              if (typeof u === 'string') {
+                return { id: u, name: u };
+              }
+              return { id: u.id, name: u.name || u.id };
+            });
+          }
+        } catch (err) {
+          if (err.response?.status === 403) {
+            // Non-admins can't list configured users; surface a note instead of an error.
+            this.availableUsers = [];
+            this.usersUnavailable = true;
+          } else {
+            throw err;
+          }
         }
       } catch (error) {
         console.error('Failed to load users:', error);
@@ -566,6 +676,14 @@ export default {
   color: var(--color-text-muted);
   margin-left: 2.5rem;
   margin-bottom: 0.5rem;
+}
+
+.toggle-help--warn {
+  color: var(--color-warning);
+}
+
+.toggle-disabled {
+  opacity: 0.5;
 }
 
 /* LLM section */

--- a/client/src/components/settings/mixins/traktDevicePolling.js
+++ b/client/src/components/settings/mixins/traktDevicePolling.js
@@ -1,0 +1,121 @@
+/**
+ * Options-API mixin encapsulating the shared Trakt device-code polling logic
+ * used by TraktMediaUsers.
+ *
+ * It owns the device-code/user-code/verification-url state, the poll timer and
+ * deadline, and the poll loop itself (deadline expiry -> stop; connected -> stop
+ * + success; any thrown error -> stop with message fallback). Pending responses
+ * (HTTP 202 with connected:false) simply do not satisfy the connected check, so
+ * polling continues until the deadline.
+ *
+ * Components parameterize the differences (which API functions to call, where to
+ * surface errors, what to do on success) via the options object passed to
+ * `startTraktPolling`.
+ */
+export default {
+  data() {
+    return {
+      isPollingTrakt: false,
+      traktDeviceCode: null,
+      traktUserCode: '',
+      traktVerificationUrl: '',
+      traktPollTimer: null,
+      traktPollDeadline: null,
+      // Per-poll-session configuration captured at start time.
+      traktPollConfig: null,
+    };
+  },
+
+  beforeUnmount() {
+    this.stopTraktPolling();
+  },
+
+  methods: {
+    /**
+     * Begin a Trakt device-code authorization flow.
+     *
+     * @param {Object} options
+     * @param {Function} options.requestCode - async () => axios response with
+     *   { device_code, user_code, verification_url, interval, expires_in }.
+     * @param {Function} options.pollToken - async (deviceCode) => axios response
+     *   with { connected, ... } (HTTP 202 while pending).
+     * @param {Function} options.onConnected - async (data) => void, called once
+     *   the account is connected (e.g. refresh status + show success toast).
+     * @param {Function} options.setError - (message|null) => void, routes error
+     *   messages to the component's own error field.
+     * @param {Function} [options.onPopupBlocked] - () => void, called when the
+     *   verification popup was blocked by the browser.
+     * @param {string} [options.windowName] - name for the verification popup.
+     * @returns {Promise<boolean>} true if polling started, false on failure.
+     */
+    async startTraktPolling({ requestCode, pollToken, onConnected, setError, onPopupBlocked, windowName = 'trakt-oauth' }) {
+      setError(null);
+      this.stopTraktPolling();
+      try {
+        const start = await requestCode();
+        const {
+          device_code: deviceCode,
+          user_code: userCode,
+          verification_url: verificationUrl,
+          interval,
+          expires_in: expiresIn,
+        } = start.data || {};
+        if (!deviceCode || !userCode || !verificationUrl) {
+          throw new Error('Invalid Trakt OAuth response');
+        }
+
+        this.traktPollConfig = { pollToken, onConnected, setError };
+        this.traktDeviceCode = deviceCode;
+        this.traktUserCode = userCode;
+        this.traktVerificationUrl = verificationUrl;
+        this.traktPollDeadline = Date.now() + Math.max(Number(expiresIn || 600), 1) * 1000;
+        const popup = window.open(verificationUrl, windowName, 'width=700,height=760');
+        if ((!popup || popup.closed) && onPopupBlocked) {
+          onPopupBlocked();
+        }
+
+        const intervalMs = Math.max(Number(interval || 5), 5) * 1000;
+        this.isPollingTrakt = true;
+        this.traktPollTimer = setInterval(() => this.pollTraktDeviceToken(), intervalMs);
+        return true;
+      } catch (err) {
+        setError(err.response?.data?.message || err.message || 'Failed to start Trakt connection');
+        return false;
+      }
+    },
+
+    async pollTraktDeviceToken() {
+      if (!this.traktDeviceCode || !this.traktPollConfig) return;
+      const { pollToken, onConnected, setError } = this.traktPollConfig;
+      if (this.traktPollDeadline && Date.now() >= this.traktPollDeadline) {
+        this.stopTraktPolling();
+        setError('Trakt authorization expired. Please try again.');
+        return;
+      }
+      try {
+        const poll = await pollToken(this.traktDeviceCode);
+        if (poll.data?.connected) {
+          this.stopTraktPolling();
+          await onConnected(poll.data);
+        }
+      } catch (err) {
+        const message = err.response?.data?.message || '';
+        this.stopTraktPolling();
+        setError(message || 'Trakt authorization failed. Please reconnect.');
+      }
+    },
+
+    stopTraktPolling() {
+      if (this.traktPollTimer) {
+        clearInterval(this.traktPollTimer);
+        this.traktPollTimer = null;
+      }
+      this.isPollingTrakt = false;
+      this.traktDeviceCode = null;
+      this.traktUserCode = '';
+      this.traktVerificationUrl = '';
+      this.traktPollDeadline = null;
+      this.traktPollConfig = null;
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Add first-class Trakt integration to SuggestArr, enabling per-media-user Trakt watch history as an augmentation source for recommendation automation jobs.

### Architecture

- **Profile-based model** — Trakt accounts are linked to media users (profiles), not auth users. Each media user can have one Trakt account via device-code OAuth.
- **Dedicated Trakt service card** — Trakt appears as a standalone service in Settings → Services with its own device-code OAuth flow (polling-based).
- **Shared `TraktWatchHistorySource`** — Both Jellyfin and Plex handlers consume Trakt watch history through a common service layer, avoiding handler-specific duplication.
- **Admin media-user Trakt management** — Admin page to view, link, unlink, and monitor Trakt accounts per media user, including token status and indicator.

### Key Changes

**Backend**
- New `trakt/` blueprint with media-user-scoped routes (link, status, unlink, device-code polling)
- `TraktClient` with full OAuth device-code flow, token refresh, and error handling
- `MediaUserAugmentor` — fetches Trakt watch history, deduplicates against local watched, produces "recent seeds" and "watched skip set"
- `IntegrationSanitizer` — strips stale Trakt tokens from global config on startup
- `database_manager.py` — `media_user_trakt_accounts` table with upsert, status reads, token refresh, and error marking
- Handler refactors in `jellyfin_handler.py` and `plex_handler.py` to consume shared Trakt augmentation
- Job runner updated for profile-based Trakt augmentation workflow

**Frontend**
- `TraktMediaUsers.vue` — admin page for linking/unlinking Trakt accounts per media user
- `traktDevicePolling.js` — mixin for device-code polling UX
- `SettingsServices.vue` — standalone Trakt service card with connect/disconnect flow
- `RecommendationFilters.vue` — toggles for Trakt watched-history skip behavior
- `JobModal.vue` — Trakt integration options in job configuration

**Tests (12 new test files)**
- `test_trakt_client.py` — full OAuth flow, token refresh, error handling
- `test_media_user_trakt_accounts.py` — DB operations, upsert idempotence, cross-provider isolation
- `test_trakt_media_user_routes.py` — admin route coverage
- `test_media_user_augmentor.py` — watch history fetch, dedup, seed generation
- `test_handler_trakt_augmentation.py` — handler integration with Trakt source
- `test_trakt_auth_disabled_e2e.py` — end-to-end augmentation with auth disabled
- `test_jobs_routes_owner.py` — job owner scoping
- `test_config.py` — expanded config test coverage

### Files Changed

46 files changed, +4,259 / −428 lines

## Future Trakt Enhancements

- **Direct Trakt recommendations** — Use Trakt API recommendation endpoints as a content source for automation jobs, alongside TMDb and LLM-based sources.
- **Jellyfin-Trakt plugin sync** — Direct integration with the [jellyfin-trakt plugin](https://github.com/jellyfin/jellyfin-plugin-trakt) to synchronize watch history between Jellyfin and Trakt without relying solely on SuggestArr-side history fetching.

## Checklist

- [x] Tests added/updated when applicable
- [x] Documentation updated when behavior or setup changed
- [x] No hardcoded styles introduced

## Notes for Reviewer

- **Plex testing needed** — I do not run Plex, so the Plex-side handler changes (`plex_handler.py`) should be verified against a live Plex instance. The shared `TraktWatchHistorySource` and merge logic is identical across Jellyfin and Plex; only the handler-specific integration points differ.
- All changes tested against Jellyfin + Trakt with auth disabled (see `test_trakt_auth_disabled_e2e.py`).