### PR TITLE
Add media users to config export with safe-by-default secret redaction

### DIFF
--- a/api_service/blueprints/admin/routes.py
+++ b/api_service/blueprints/admin/routes.py
@@ -13,28 +13,13 @@ from api_service.auth.middleware import require_role
 from api_service.config.config import load_env_vars
 from api_service.config.logger_manager import LoggerManager
 from api_service.db.database_manager import DatabaseManager
+from api_service.services.config_secrets import (
+    redact_settings,
+    strip_integration_secrets,
+)
 
 logger = LoggerManager.get_logger("AdminRoute")
 admin_bp = Blueprint('admin', __name__)
-
-# ---------------------------------------------------------------------------
-# Secret-field detection
-# ---------------------------------------------------------------------------
-
-# Substring patterns used to identify secret fields inside integration configs.
-# Any integration config key whose name contains one of these strings is treated
-# as sensitive and stripped when include_secrets=false.
-_INTEGRATION_SECRET_PATTERNS = ('token', 'api_key', 'password', 'secret')
-
-# Top-level keys in the settings dict (config.yaml) that hold secrets.
-_SETTINGS_SECRET_KEYS = frozenset({
-    'TMDB_API_KEY', 'OMDB_API_KEY',
-    'PLEX_TOKEN', 'JELLYFIN_TOKEN',
-    'SEER_TOKEN', 'SEER_USER_PSW', 'SEER_SESSION_TOKEN',
-    'DB_PASSWORD',
-    'OPENAI_API_KEY',
-    'TRAKT_CLIENT_SECRET', 'TRAKT_ACCESS_TOKEN', 'TRAKT_REFRESH_TOKEN',
-})
 
 # ---------------------------------------------------------------------------
 # Legacy v1 format: flat env-var dict → v2 integrations dict
@@ -65,41 +50,6 @@ _V1_INTEGRATION_MAP = {
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _strip_integration_secrets(cfg: dict) -> dict:
-    """
-    Return a copy of an integration config with secret fields replaced by '***'.
-
-    A field is considered secret if its name contains any string from
-    _INTEGRATION_SECRET_PATTERNS.
-
-    Args:
-        cfg: Raw integration config dict.
-
-    Returns:
-        dict with secret values replaced by '***'.
-    """
-    return {
-        k: '***' if any(p in k for p in _INTEGRATION_SECRET_PATTERNS) else v
-        for k, v in cfg.items()
-    }
-
-
-def _redact_settings(settings: dict) -> dict:
-    """
-    Return a copy of the settings dict with known secret keys replaced by '***'.
-
-    Args:
-        settings: Flat settings dict from load_env_vars().
-
-    Returns:
-        dict with secret values replaced by '***'.
-    """
-    return {
-        k: ('***' if k in _SETTINGS_SECRET_KEYS and v else v)
-        for k, v in settings.items()
-    }
 
 
 def _integrations_from_v1(payload: dict) -> dict:
@@ -156,10 +106,10 @@ def export_config():
 
     if not include_secrets:
         integrations = {
-            svc: _strip_integration_secrets(cfg)
+            svc: strip_integration_secrets(cfg)
             for svc, cfg in integrations.items()
         }
-        settings = _redact_settings(settings)
+        settings = redact_settings(settings)
 
     return jsonify({
         'schema_version': 2,

--- a/api_service/blueprints/config/routes.py
+++ b/api_service/blueprints/config/routes.py
@@ -558,17 +558,25 @@ def export_config():
     """
     Export the full application configuration as a portable JSON snapshot.
 
-    Requires admin role.  The response includes API keys in plain text so that
-    a configuration backup can be fully restored; callers must treat the
-    response as sensitive.
+    Requires admin role.  Secret values are redacted by default; pass
+    ``include_secrets=true`` for a fully restorable backup.
+
+    Query parameters:
+        include_secrets (str): 'true' to include raw secret values (API keys,
+            tokens, passwords) and Trakt OAuth tokens.  Defaults to 'false'.
 
     Returns:
-        200 JSON with keys: version, integrations, settings.
+        200 JSON with keys: version, integrations, settings, media_users.
         500 on unexpected server error.
     """
     try:
-        snapshot = ConfigService.export_config()
-        logger.info("Admin config export requested by user '%s'", _current_username())
+        include_secrets = request.args.get('include_secrets', 'false').lower() == 'true'
+        snapshot = ConfigService.export_config(include_secrets=include_secrets)
+        logger.info(
+            "Admin config export requested by user '%s' (include_secrets=%s)",
+            _current_username(),
+            include_secrets,
+        )
         return jsonify(snapshot), 200
     except Exception as e:
         logger.error('Error exporting configuration: %s', e, exc_info=True)

--- a/api_service/db/database_manager.py
+++ b/api_service/db/database_manager.py
@@ -2621,6 +2621,27 @@ class DatabaseManager:
         return {"id": row[0], "provider": row[1], "external_user_id": row[2],
                 "external_username": row[3], "created_at": row[4]}
 
+    def get_all_media_user_identities(self) -> List[Dict[str, Any]]:
+        """Return all media-user identity rows ordered by provider and external id."""
+        query = (
+            "SELECT id, provider, external_user_id, external_username, created_at "
+            "FROM media_user_identities ORDER BY provider, external_user_id"
+        )
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query)
+            rows = cursor.fetchall()
+        return [
+            {
+                "id": row[0],
+                "provider": row[1],
+                "external_user_id": row[2],
+                "external_username": row[3],
+                "created_at": row[4],
+            }
+            for row in rows
+        ]
+
     # ---- trakt_account_links --------------------------------------------------
 
     def upsert_trakt_account_link(

--- a/api_service/services/config_secrets.py
+++ b/api_service/services/config_secrets.py
@@ -1,0 +1,53 @@
+"""Shared helpers for redacting secrets in configuration export/import."""
+
+from typing import Any, Dict
+
+REDACTED = '***'
+
+INTEGRATION_SECRET_PATTERNS = ('token', 'api_key', 'password', 'secret')
+
+SETTINGS_SECRET_KEYS = frozenset({
+    'TMDB_API_KEY', 'OMDB_API_KEY',
+    'PLEX_TOKEN', 'JELLYFIN_TOKEN',
+    'SEER_TOKEN', 'SEER_USER_PSW', 'SEER_SESSION_TOKEN',
+    'DB_PASSWORD',
+    'OPENAI_API_KEY',
+    'TRAKT_CLIENT_SECRET', 'TRAKT_ACCESS_TOKEN', 'TRAKT_REFRESH_TOKEN',
+})
+
+EXPORT_SENSITIVE_DATA_WARNING = (
+    'This export contains live credentials (API keys, tokens, and passwords). '
+    'Treat the file as sensitive and do not share it.'
+)
+
+
+def is_redacted(value: Any) -> bool:
+    """Return True when a value is the export redaction placeholder."""
+    return value == REDACTED
+
+
+def strip_integration_secrets(cfg: dict) -> dict:
+    """Return a copy of an integration config with secret fields redacted."""
+    return {
+        key: REDACTED if any(pattern in key for pattern in INTEGRATION_SECRET_PATTERNS) else value
+        for key, value in cfg.items()
+    }
+
+
+def redact_settings(settings: dict) -> dict:
+    """Return a copy of settings with known secret keys redacted."""
+    return {
+        key: (REDACTED if key in SETTINGS_SECRET_KEYS and value else value)
+        for key, value in settings.items()
+    }
+
+
+def merge_integration_config(service: str, incoming: Dict[str, Any], existing: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge an imported integration config, preserving secrets omitted as redacted."""
+    from api_service.services.integration_sanitizer import sanitize_integration_config
+
+    merged = dict(existing or {})
+    for key, value in incoming.items():
+        if not is_redacted(value):
+            merged[key] = value
+    return sanitize_integration_config(service, merged)

--- a/api_service/services/config_service.py
+++ b/api_service/services/config_service.py
@@ -12,6 +12,14 @@ from api_service.config.config import (
 )
 from api_service.config.logger_manager import LoggerManager
 from api_service.db.database_manager import DatabaseManager
+from api_service.services.config_secrets import (
+    EXPORT_SENSITIVE_DATA_WARNING,
+    REDACTED,
+    is_redacted,
+    merge_integration_config,
+    redact_settings,
+    strip_integration_secrets,
+)
 from api_service.services.integration_sanitizer import sanitize_integration_config
 
 logger = LoggerManager.get_logger(__name__)
@@ -63,8 +71,13 @@ def _sanitize_integration_config(service: str, config: dict) -> dict:
     return sanitize_integration_config(service, config)
 
 
-def _export_media_users(db: DatabaseManager) -> list:
-    """Serialize media-user identities and per-user Trakt data for export."""
+def _export_media_users(db: DatabaseManager, *, include_secrets: bool = False) -> list:
+    """Serialize media-user identities and per-user Trakt data for export.
+
+    Account metadata and source settings are always included.  When OAuth tokens
+    exist, ``oauth_tokens`` is always emitted; secret fields are redacted unless
+    ``include_secrets`` is True.
+    """
     media_users = []
     for identity in db.get_all_media_user_identities():
         entry = {
@@ -85,11 +98,18 @@ def _export_media_users(db: DatabaseManager) -> list:
         }
         tokens = db.get_trakt_oauth_tokens(link["id"])
         if tokens:
-            trakt_entry["oauth_tokens"] = {
-                "access_token": tokens["access_token"],
-                "refresh_token": tokens["refresh_token"],
-                "expires_at": tokens.get("expires_at"),
-            }
+            if include_secrets:
+                trakt_entry["oauth_tokens"] = {
+                    "access_token": tokens["access_token"],
+                    "refresh_token": tokens["refresh_token"],
+                    "expires_at": tokens.get("expires_at"),
+                }
+            else:
+                trakt_entry["oauth_tokens"] = {
+                    "access_token": REDACTED,
+                    "refresh_token": REDACTED,
+                    "expires_at": None,
+                }
         trakt_entry["sources"] = [
             {
                 "source_type": source["source_type"],
@@ -136,7 +156,11 @@ def _import_media_users(db: DatabaseManager, media_users: list) -> None:
         if isinstance(oauth, dict):
             access_token = oauth.get("access_token")
             refresh_token = oauth.get("refresh_token")
-            if access_token and refresh_token:
+            if (
+                access_token and refresh_token
+                and not is_redacted(access_token)
+                and not is_redacted(refresh_token)
+            ):
                 db.upsert_trakt_oauth_tokens(
                     link_id=link_id,
                     access_token=access_token,
@@ -187,24 +211,39 @@ class ConfigService:
         return load_env_vars()
 
     @staticmethod
-    def export_config() -> dict:
-        """Build a fully-restorable configuration snapshot.
+    def export_config(*, include_secrets: bool = False) -> dict:
+        """Build a configuration snapshot.
 
-        The snapshot has two sections:
-        - ``integrations``: per-service credentials read directly from the DB
-          integrations table (api_url, api_key, etc.).  API keys are included
-          verbatim – the caller must ensure only admin users receive this.
-        - ``settings``: every other configuration value stored in config.yaml
-          (filters, scheduling, feature flags, Plex/Trakt credentials, …).
+        By default, secret values are redacted so the export is safer to share
+        for troubleshooting.  Pass ``include_secrets=True`` for a fully
+        restorable backup.
+
+        The snapshot has three sections:
+        - ``integrations``: per-service credentials from the DB integrations
+          table.  Secret fields are redacted unless ``include_secrets`` is True.
+        - ``settings``: configuration values from config.yaml, with known
+          secret keys redacted by default.
+        - ``media_users``: media-user identities with Trakt account metadata
+          and source settings.  Per-user OAuth tokens follow ``include_secrets``.
+
+        Args:
+            include_secrets: When True, include raw secret values and Trakt
+                OAuth tokens.  Defaults to False.
 
         Returns:
-            dict with keys ``version``, ``integrations``, ``settings``.
+            dict with keys ``version``, ``integrations``, ``settings``,
+            ``media_users``, and optionally ``warnings``.
         """
         db = DatabaseManager()
         integrations = {
             service: _sanitize_integration_config(service, cfg)
             for service, cfg in db.get_all_integrations().items()
         }
+        if not include_secrets:
+            integrations = {
+                service: strip_integration_secrets(cfg)
+                for service, cfg in integrations.items()
+            }
         logger.info(
             "Config export: collected %d integration(s): %s",
             len(integrations),
@@ -217,13 +256,18 @@ class ConfigService:
             for k, v in config.items()
             if k in _VALID_SETTING_KEYS
         }
+        if not include_secrets:
+            settings = redact_settings(settings)
 
-        return {
+        snapshot = {
             "version": CURRENT_VERSION,
             "integrations": integrations,
             "settings": settings,
-            "media_users": _export_media_users(db),
+            "media_users": _export_media_users(db, include_secrets=include_secrets),
         }
+        if include_secrets:
+            snapshot["warnings"] = [EXPORT_SENSITIVE_DATA_WARNING]
+        return snapshot
 
     @staticmethod
     def import_config(data: dict) -> None:
@@ -262,6 +306,8 @@ class ConfigService:
                 )
                 continue
             service_cfg = _sanitize_integration_config(service, service_cfg)
+            existing = db.get_integration(service) or {}
+            service_cfg = merge_integration_config(service, service_cfg, existing)
             # Log non-sensitive fields only.
             safe = _redact_for_log(service_cfg)
             logger.info("Importing integration '%s' %s", service, safe)
@@ -273,7 +319,7 @@ class ConfigService:
             current_config = load_env_vars()
             updated_keys = []
             for key in _VALID_SETTING_KEYS:
-                if key in settings:
+                if key in settings and not is_redacted(settings[key]):
                     current_config[key] = settings[key]
                     updated_keys.append(key)
             logger.info("Restoring %d setting key(s) from import", len(updated_keys))

--- a/api_service/services/config_service.py
+++ b/api_service/services/config_service.py
@@ -63,6 +63,106 @@ def _sanitize_integration_config(service: str, config: dict) -> dict:
     return sanitize_integration_config(service, config)
 
 
+def _export_media_users(db: DatabaseManager) -> list:
+    """Serialize media-user identities and per-user Trakt data for export."""
+    media_users = []
+    for identity in db.get_all_media_user_identities():
+        entry = {
+            "provider": identity["provider"],
+            "external_user_id": identity["external_user_id"],
+            "external_username": identity.get("external_username"),
+        }
+        link = db.get_trakt_account_link(identity["id"])
+        if not link:
+            media_users.append(entry)
+            continue
+
+        trakt_entry = {
+            "trakt_user_id": link.get("trakt_user_id"),
+            "trakt_username": link.get("trakt_username"),
+            "token_source": link.get("token_source"),
+            "status": link.get("status"),
+        }
+        tokens = db.get_trakt_oauth_tokens(link["id"])
+        if tokens:
+            trakt_entry["oauth_tokens"] = {
+                "access_token": tokens["access_token"],
+                "refresh_token": tokens["refresh_token"],
+                "expires_at": tokens.get("expires_at"),
+            }
+        trakt_entry["sources"] = [
+            {
+                "source_type": source["source_type"],
+                "source_key": source["source_key"],
+                "list_id": source.get("list_id"),
+                "list_slug": source.get("list_slug"),
+                "username": source.get("username"),
+                "enabled": source.get("enabled", True),
+                "use_as_seed": source.get("use_as_seed", True),
+                "use_as_exclusion": source.get("use_as_exclusion", True),
+            }
+            for source in db.get_trakt_sources(identity["id"])
+        ]
+        entry["trakt"] = trakt_entry
+        media_users.append(entry)
+    return media_users
+
+
+def _import_media_users(db: DatabaseManager, media_users: list) -> None:
+    """Restore media-user identities and per-user Trakt data from a snapshot."""
+    for entry in media_users:
+        if not isinstance(entry, dict):
+            continue
+        provider = entry.get("provider")
+        external_user_id = entry.get("external_user_id")
+        if not provider or external_user_id is None:
+            continue
+
+        identity = db.upsert_media_user_identity(
+            str(provider), str(external_user_id), entry.get("external_username"),
+        )
+        trakt = entry.get("trakt")
+        if not isinstance(trakt, dict):
+            continue
+
+        link_id = db.upsert_trakt_account_link(
+            media_user_identity_id=identity["id"],
+            trakt_user_id=trakt.get("trakt_user_id"),
+            trakt_username=trakt.get("trakt_username"),
+            token_source=trakt.get("token_source") or "manual_oauth",
+            status=trakt.get("status") or "connected",
+        )
+        oauth = trakt.get("oauth_tokens")
+        if isinstance(oauth, dict):
+            access_token = oauth.get("access_token")
+            refresh_token = oauth.get("refresh_token")
+            if access_token and refresh_token:
+                db.upsert_trakt_oauth_tokens(
+                    link_id=link_id,
+                    access_token=access_token,
+                    refresh_token=refresh_token,
+                    expires_at=oauth.get("expires_at"),
+                )
+        for source in trakt.get("sources") or []:
+            if not isinstance(source, dict):
+                continue
+            source_type = source.get("source_type")
+            source_key = source.get("source_key")
+            if not source_type or not source_key:
+                continue
+            db.upsert_trakt_source(
+                media_user_identity_id=identity["id"],
+                source_type=source_type,
+                source_key=source_key,
+                enabled=bool(source.get("enabled", True)),
+                use_as_seed=bool(source.get("use_as_seed", True)),
+                use_as_exclusion=bool(source.get("use_as_exclusion", True)),
+                list_id=source.get("list_id"),
+                list_slug=source.get("list_slug"),
+                username=source.get("username"),
+            )
+
+
 def _redact_for_log(config: dict) -> dict:
     """Return a copy with secret-like keys redacted for logging."""
     safe = {}
@@ -122,6 +222,7 @@ class ConfigService:
             "version": CURRENT_VERSION,
             "integrations": integrations,
             "settings": settings,
+            "media_users": _export_media_users(db),
         }
 
     @staticmethod
@@ -178,6 +279,11 @@ class ConfigService:
             logger.info("Restoring %d setting key(s) from import", len(updated_keys))
             save_env_vars(current_config)
 
-        # --- 3. Refresh DB config in case DB connection settings changed ------
+        # --- 3. Restore media users (optional) --------------------------------
+        media_users = data.get("media_users") or []
+        if media_users:
+            _import_media_users(db, media_users)
+
+        # --- 4. Refresh DB config in case DB connection settings changed ------
         db.refresh_config()
         logger.info("Config import completed successfully")

--- a/api_service/test/test_config.py
+++ b/api_service/test/test_config.py
@@ -336,7 +336,7 @@ class TestConfig(unittest.TestCase):
 
         self.assertEqual(exported['integrations']['trakt'], {
             'client_id': 'cid',
-            'client_secret': 'secret',
+            'client_secret': '***',
         })
         self.assertNotIn('TRAKT_ACCESS_TOKEN', exported['settings'])
         self.assertNotIn('TRAKT_REFRESH_TOKEN', exported['settings'])
@@ -390,6 +390,192 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(safe_payload['client_id'], 'cid')
         self.assertEqual(safe_payload['client_secret'], '***')
 
+    def test_config_export_redacts_integration_secrets_by_default(self):
+        self._db_manager_cls.return_value.get_all_integrations.return_value = {
+            'plex': {'api_url': 'http://plex', 'api_key': 'plex-secret'},
+            'trakt': {'client_id': 'cid', 'client_secret': 'secret'},
+        }
+
+        exported = config_service.ConfigService.export_config()
+
+        self.assertEqual(exported['integrations']['plex']['api_url'], 'http://plex')
+        self.assertEqual(exported['integrations']['plex']['api_key'], '***')
+        self.assertEqual(exported['integrations']['trakt']['client_id'], 'cid')
+        self.assertEqual(exported['integrations']['trakt']['client_secret'], '***')
+
+    def test_config_export_redacts_trakt_oauth_tokens_by_default(self):
+        import api_service.db.database_manager as dm_mod
+
+        real_db_cls = DatabaseManager
+        real_db_cls._instance = None
+        fd, db_file = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        path_patch = patch.object(dm_mod, 'DB_PATH', db_file)
+        env_patch = patch(
+            'api_service.db.database_manager.load_env_vars',
+            return_value={'DB_TYPE': 'sqlite'},
+        )
+        config_db_patch = patch(
+            'api_service.services.config_service.DatabaseManager',
+            real_db_cls,
+        )
+        path_patch.start()
+        env_patch.start()
+        config_db_patch.start()
+
+        try:
+            manager = real_db_cls()
+            identity = manager.upsert_media_user_identity('jellyfin', 'jf-1', 'alice')
+            link_id = manager.upsert_trakt_account_link(
+                media_user_identity_id=identity['id'],
+                trakt_user_id='t-1',
+                trakt_username='trakt_alice',
+            )
+            manager.upsert_trakt_oauth_tokens(
+                link_id, 'access-token', 'refresh-token', 1234567890,
+            )
+
+            exported = config_service.ConfigService.export_config()
+
+            trakt = exported['media_users'][0]['trakt']
+            self.assertEqual(trakt['trakt_username'], 'trakt_alice')
+            self.assertEqual(trakt['oauth_tokens'], {
+                'access_token': '***',
+                'refresh_token': '***',
+                'expires_at': None,
+            })
+            self.assertNotIn('warnings', exported)
+        finally:
+            real_db_cls._instance = None
+            config_db_patch.stop()
+            env_patch.stop()
+            path_patch.stop()
+            try:
+                os.unlink(db_file)
+            except FileNotFoundError:
+                pass
+
+    def test_config_export_includes_secrets_when_requested(self):
+        import api_service.db.database_manager as dm_mod
+
+        real_db_cls = DatabaseManager
+        real_db_cls._instance = None
+        fd, db_file = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        path_patch = patch.object(dm_mod, 'DB_PATH', db_file)
+        env_patch = patch(
+            'api_service.db.database_manager.load_env_vars',
+            return_value={'DB_TYPE': 'sqlite'},
+        )
+        config_db_patch = patch(
+            'api_service.services.config_service.DatabaseManager',
+            real_db_cls,
+        )
+        path_patch.start()
+        env_patch.start()
+        config_db_patch.start()
+
+        try:
+            manager = real_db_cls()
+            manager.set_integration('trakt', {'client_id': 'cid', 'client_secret': 'secret'})
+            identity = manager.upsert_media_user_identity('jellyfin', 'jf-1', 'alice')
+            link_id = manager.upsert_trakt_account_link(
+                media_user_identity_id=identity['id'],
+                trakt_user_id='t-1',
+                trakt_username='trakt_alice',
+            )
+            manager.upsert_trakt_oauth_tokens(
+                link_id, 'access-token', 'refresh-token', 1234567890,
+            )
+
+            exported = config_service.ConfigService.export_config(include_secrets=True)
+
+            tokens = exported['media_users'][0]['trakt']['oauth_tokens']
+            self.assertEqual(tokens['access_token'], 'access-token')
+            self.assertEqual(tokens['refresh_token'], 'refresh-token')
+            self.assertEqual(exported['integrations']['trakt']['client_secret'], 'secret')
+            self.assertIn('warnings', exported)
+        finally:
+            real_db_cls._instance = None
+            config_db_patch.stop()
+            env_patch.stop()
+            path_patch.stop()
+            try:
+                os.unlink(db_file)
+            except FileNotFoundError:
+                pass
+
+    def test_config_import_preserves_existing_secrets_when_snapshot_is_redacted(self):
+        self._db_manager_cls.return_value.get_all_integrations.return_value = {}
+        self._db_manager_cls.return_value.get_integration.return_value = {
+            'api_url': 'http://plex',
+            'api_key': 'live-token',
+        }
+        self._db_manager_cls.return_value.refresh_config.return_value = None
+
+        config_service.ConfigService.import_config({
+            'version': config_service.CURRENT_VERSION,
+            'integrations': {
+                'plex': {'api_url': 'http://new-plex', 'api_key': '***'},
+            },
+            'settings': {'PLEX_TOKEN': '***'},
+        })
+
+        written = self._db_manager_cls.return_value.set_integration.call_args.args[1]
+        self.assertEqual(written['api_url'], 'http://new-plex')
+        self.assertEqual(written['api_key'], 'live-token')
+
+    def test_config_import_preserves_oauth_tokens_when_snapshot_is_redacted(self):
+        import api_service.db.database_manager as dm_mod
+
+        real_db_cls = DatabaseManager
+        real_db_cls._instance = None
+        fd, db_file = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        path_patch = patch.object(dm_mod, 'DB_PATH', db_file)
+        env_patch = patch(
+            'api_service.db.database_manager.load_env_vars',
+            return_value={'DB_TYPE': 'sqlite'},
+        )
+        config_db_patch = patch(
+            'api_service.services.config_service.DatabaseManager',
+            real_db_cls,
+        )
+        path_patch.start()
+        env_patch.start()
+        config_db_patch.start()
+
+        try:
+            manager = real_db_cls()
+            identity = manager.upsert_media_user_identity('jellyfin', 'jf-1', 'alice')
+            link_id = manager.upsert_trakt_account_link(
+                media_user_identity_id=identity['id'],
+                trakt_user_id='t-1',
+                trakt_username='trakt_alice',
+            )
+            manager.upsert_trakt_oauth_tokens(
+                link_id, 'live-access', 'live-refresh', 1234567890,
+            )
+
+            exported = config_service.ConfigService.export_config(include_secrets=False)
+            config_service.ConfigService.import_config(exported)
+
+            tokens = manager.get_trakt_oauth_tokens(link_id)
+            self.assertEqual(tokens['access_token'], 'live-access')
+            self.assertEqual(tokens['refresh_token'], 'live-refresh')
+        finally:
+            real_db_cls._instance = None
+            config_db_patch.stop()
+            env_patch.stop()
+            path_patch.stop()
+            try:
+                os.unlink(db_file)
+            except FileNotFoundError:
+                pass
+
     def test_config_export_import_media_users_roundtrip(self):
         import api_service.db.database_manager as dm_mod
 
@@ -433,7 +619,7 @@ class TestConfig(unittest.TestCase):
                 use_as_exclusion=False,
             )
 
-            exported = config_service.ConfigService.export_config()
+            exported = config_service.ConfigService.export_config(include_secrets=True)
             self.assertEqual(len(exported['media_users']), 1)
 
             real_db_cls._instance = None
@@ -458,6 +644,28 @@ class TestConfig(unittest.TestCase):
                 os.unlink(db_file)
             except FileNotFoundError:
                 pass
+
+    def test_config_export_rejects_non_admin(self):
+        from api_service.blueprints.config.routes import config_bp
+        from flask import Flask, g
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        self._caller = {'username': 'viewer', 'role': 'user'}
+
+        @app.before_request
+        def inject_caller():
+            g.current_user = self._caller
+
+        app.register_blueprint(config_bp, url_prefix='/api/config')
+        client = app.test_client()
+
+        resp = client.get('/api/config/export')
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.get_json(), {'error': 'Insufficient permissions'})
+
+        resp = client.get('/api/config/export?include_secrets=true')
+        self.assertEqual(resp.status_code, 403)
 
     def test_config_status_exposes_trakt_app_configured_without_secret_values(self):
         from api_service.blueprints.config.routes import config_bp

--- a/api_service/test/test_config.py
+++ b/api_service/test/test_config.py
@@ -390,6 +390,75 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(safe_payload['client_id'], 'cid')
         self.assertEqual(safe_payload['client_secret'], '***')
 
+    def test_config_export_import_media_users_roundtrip(self):
+        import api_service.db.database_manager as dm_mod
+
+        real_db_cls = DatabaseManager
+        real_db_cls._instance = None
+        fd, db_file = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        path_patch = patch.object(dm_mod, 'DB_PATH', db_file)
+        env_patch = patch(
+            'api_service.db.database_manager.load_env_vars',
+            return_value={'DB_TYPE': 'sqlite'},
+        )
+        config_db_patch = patch(
+            'api_service.services.config_service.DatabaseManager',
+            real_db_cls,
+        )
+        path_patch.start()
+        env_patch.start()
+        config_db_patch.start()
+
+        try:
+            manager = real_db_cls()
+            identity = manager.upsert_media_user_identity('jellyfin', 'jf-1', 'alice')
+            link_id = manager.upsert_trakt_account_link(
+                media_user_identity_id=identity['id'],
+                trakt_user_id='t-1',
+                trakt_username='trakt_alice',
+                token_source='manual_oauth',
+                status='connected',
+            )
+            manager.upsert_trakt_oauth_tokens(
+                link_id, 'access-token', 'refresh-token', 1234567890,
+            )
+            manager.upsert_trakt_source(
+                media_user_identity_id=identity['id'],
+                source_type='watched_history',
+                source_key='watched_history',
+                enabled=True,
+                use_as_seed=True,
+                use_as_exclusion=False,
+            )
+
+            exported = config_service.ConfigService.export_config()
+            self.assertEqual(len(exported['media_users']), 1)
+
+            real_db_cls._instance = None
+            manager = real_db_cls()
+            config_service.ConfigService.import_config(exported)
+
+            restored = manager.get_media_user_identity('jellyfin', 'jf-1')
+            self.assertEqual(restored['external_username'], 'alice')
+            link = manager.get_trakt_account_link(restored['id'])
+            self.assertEqual(link['trakt_username'], 'trakt_alice')
+            tokens = manager.get_trakt_oauth_tokens(link['id'])
+            self.assertEqual(tokens['access_token'], 'access-token')
+            sources = manager.get_trakt_sources(restored['id'])
+            self.assertEqual(len(sources), 1)
+            self.assertFalse(sources[0]['use_as_exclusion'])
+        finally:
+            real_db_cls._instance = None
+            config_db_patch.stop()
+            env_patch.stop()
+            path_patch.stop()
+            try:
+                os.unlink(db_file)
+            except FileNotFoundError:
+                pass
+
     def test_config_status_exposes_trakt_app_configured_without_secret_values(self):
         from api_service.blueprints.config.routes import config_bp
         from flask import Flask

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -178,9 +178,12 @@ export const setCleanupSettings = (payload) => axios.post('/api/cleanup/settings
 export const runCleanupNow = (dryRun = null) => axios.post('/api/cleanup/run', dryRun === null ? {} : { dry_run: dryRun });
 export const getCleanupLog = (limit = 100) => axios.get('/api/cleanup/log', { params: { limit } });
 
-// Config export: download a full configuration snapshot (admin only, includes API keys)
-export const exportConfig = () => {
-    return axios.get('/api/config/export', { responseType: 'json' });
+// Config export: download a configuration snapshot (admin only)
+export const exportConfig = (includeSecrets = false) => {
+    return axios.get('/api/config/export', {
+        responseType: 'json',
+        params: { include_secrets: includeSecrets ? 'true' : 'false' },
+    });
 };
 
 // Config import: restore a configuration snapshot (admin only)

--- a/client/src/components/DashboardPage.vue
+++ b/client/src/components/DashboardPage.vue
@@ -158,7 +158,7 @@
         
         <div v-if="isAdmin" class="footer-actions" data-tour-id="footer-actions">
           <button
-            @click="exportConfig"
+            @click="showExportModal = true"
             class="btn btn-outline"
             :disabled="isLoading"
             title="Export configuration to JSON file">
@@ -263,6 +263,48 @@
         accept=".json"
         style="display: none"
       />
+
+      <!-- Export Configuration Modal -->
+      <transition name="fade">
+        <div v-if="showExportModal" class="modal-overlay" @click.self="showExportModal = false">
+          <div class="modal modal--sm" role="dialog" aria-modal="true" aria-labelledby="export-modal-title">
+            <div class="modal-header">
+              <div class="modal-title-wrap">
+                <h3 class="modal-title" id="export-modal-title">
+                  <i class="fas fa-download"></i> Export Configuration
+                </h3>
+                <p class="modal-subtitle">Download a JSON snapshot of your settings.</p>
+              </div>
+              <button type="button" class="modal-close" aria-label="Close export modal" @click="showExportModal = false">
+                <i class="fas fa-times"></i>
+              </button>
+            </div>
+
+            <div class="modal-body">
+              <p>Non-secret settings, media user identities, and Trakt account metadata are included by default. Live credentials are redacted unless you opt in below.</p>
+              <label class="export-sensitive-option">
+                <input v-model="exportIncludeSecrets" type="checkbox">
+                Include all secrets (full backup)
+              </label>
+              <p v-if="exportIncludeSecrets" class="export-sensitive-warning">
+                <i class="fas fa-exclamation-triangle"></i>
+                This export will contain API keys, tokens, and passwords. Do not share it for troubleshooting or attach it to public issues.
+              </p>
+            </div>
+
+            <div class="modal-footer">
+              <button @click="showExportModal = false" class="btn btn-outline">
+                <i class="fas fa-times"></i>
+                Cancel
+              </button>
+              <button @click="confirmExportConfig" class="btn btn-primary">
+                <i class="fas fa-download"></i>
+                Export
+              </button>
+            </div>
+          </div>
+        </div>
+      </transition>
 
       <!-- Reset Confirmation Modal -->
       <transition name="fade">
@@ -396,6 +438,8 @@ export default {
       loadingMessage: 'Processing...',
       activeTab: 'requests',
       showResetModal: false,
+      showExportModal: false,
+      exportIncludeSecrets: false,
       showChangelogModal: false,
       changelogData: null,
       isLoadingChangelog: false,
@@ -966,12 +1010,19 @@ export default {
       this.$router.push({ name: 'Home' });
     },
 
-    async exportConfig() {
+    async confirmExportConfig() {
+      const includeSecrets = this.exportIncludeSecrets;
+      this.showExportModal = false;
+      this.exportIncludeSecrets = false;
+      await this.exportConfig(includeSecrets);
+    },
+
+    async exportConfig(includeSecrets = false) {
       this.loadingMessage = 'Exporting configuration...';
       this.isLoading = true;
     
       try {
-        const response = await exportConfig();
+        const response = await exportConfig(includeSecrets);
         const configData = response.data;
       
         const blob = new Blob(
@@ -986,10 +1037,13 @@ export default {
         link.click();
         URL.revokeObjectURL(url);
       
+        const warnings = configData.warnings || [];
         this.$toast.open({
-          message: 'Configuration exported successfully!',
-          type: 'success',
-          duration: 3000,
+          message: warnings.length
+            ? warnings[0]
+            : 'Configuration exported successfully!',
+          type: warnings.length ? 'warning' : 'success',
+          duration: warnings.length ? 8000 : 3000,
           position: 'top-right'
         });
       

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -304,6 +304,8 @@ SuggestArr stores:
 
 SuggestArr does not expose Trakt access tokens in API responses or frontend lists.
 
+Configuration export (Dashboard **Export**) can include Trakt link metadata and source settings by default. OAuth tokens are redacted unless you choose a full backup. See [UI Export and Import](#ui-export-and-import).
+
 ### Create a Trakt OAuth app
 
 1. Open <https://trakt.tv/oauth/applications>.
@@ -637,24 +639,72 @@ SuggestArr has two backup methods:
 
 In the footer of the web interface, admins can use:
 
-- `Export`: downloads a full configuration snapshot as a JSON file.
+- `Export`: downloads a configuration snapshot as a JSON file.
 - `Import`: restores a configuration snapshot from a previously exported JSON file.
 
 Use this when you want to start a new SuggestArr instance and restore the same configuration without manually entering every value again.
 
-Recommended flow:
+The Dashboard uses `GET /api/config/export` and `POST /api/config/import`. This is the **canonical** backup path and restores integrations, settings, and per-user Trakt data.
+
+#### What is included
+
+Each export contains:
+
+- `integrations`: service credentials from the database (URLs, API keys, tokens, and similar fields).
+- `settings`: non-integration configuration from `config.yaml` (filters, scheduling, feature flags, and similar values).
+- `media_users`: media-server user identities and per-user Trakt link metadata (username, status, source settings).
+
+Trakt app credentials remain under `integrations.trakt`. Per-user OAuth tokens are stored under `media_users[].trakt.oauth_tokens`.
+
+Config schema version is `2`. Older exports without `media_users` still import normally.
+
+#### Safe export vs full backup
+
+By default, exports are **safe for troubleshooting**:
+
+- Secret fields are redacted as `***` (API keys, tokens, passwords, Trakt `client_secret`, and similar values).
+- When OAuth tokens exist, `oauth_tokens` is still present but redacted:
+
+```json
+"oauth_tokens": {
+  "access_token": "***",
+  "refresh_token": "***",
+  "expires_at": null
+}
+```
+
+To download a **fully restorable backup**, check **Include all secrets (full backup)** in the export dialog. This sends `include_secrets=true` and includes live credentials plus Trakt OAuth tokens. SuggestArr shows a warning when secrets are included.
+
+Treat full backups like password files. Do not attach them to GitHub issues, Discord, or other public channels.
+
+#### Import behavior
+
+Import merges the snapshot into the running instance:
+
+- Redacted `***` values do **not** overwrite existing secrets.
+- If you import a safe export on a fresh instance, service credentials and Trakt OAuth tokens must be re-entered or re-linked.
+- If you import a safe export on an instance that already has credentials, existing secrets are preserved.
+- A full backup import restores credentials and Trakt tokens without re-linking.
+
+After importing a safe export, Trakt links may still show as connected in metadata, but Trakt features will not work until each user links Trakt again unless the import included live OAuth tokens.
+
+#### Recommended flow
 
 1. Open the old SuggestArr instance.
 2. Click `Export` in the footer.
-3. Save the downloaded JSON file somewhere safe.
-4. Start the new SuggestArr instance.
-5. Complete initial admin setup if required.
-6. Click `Import` in the footer.
-7. Select the exported JSON file.
-8. Review services, database, jobs, and advanced settings.
-9. Save or restart the container if needed.
+3. For disaster recovery, enable **Include all secrets (full backup)**. For troubleshooting or sharing config structure, leave it unchecked.
+4. Save the downloaded JSON file somewhere safe.
+5. Start the new SuggestArr instance.
+6. Complete initial admin setup if required.
+7. Click `Import` in the footer.
+8. Select the exported JSON file.
+9. Review services, database, jobs, and advanced settings.
+10. Re-link Trakt accounts if you imported a safe export without OAuth tokens.
+11. Save or restart the container if needed.
 
-The exported JSON can include sensitive values such as API keys and tokens. Store it like a password file.
+#### API note
+
+`GET /api/admin/export-config` is a separate, older endpoint. It exports integrations and settings only and does **not** include `media_users` or restore them on import. Use the Dashboard export/import flow (or `/api/config/export` directly) when Trakt user links must move with the instance.
 
 ### Filesystem Backup
 


### PR DESCRIPTION
## Summary

- Extend Dashboard config export/import (`/api/config/export`, `/api/config/import`) with an optional `media_users` array so media-server identities and per-user Trakt link metadata survive backup and restore.
- Redact secrets by default (integration API keys/tokens, settings secrets, and Trakt OAuth tokens) so exports are safer to share for troubleshooting; admins can opt in to a full backup via `include_secrets=true` or the UI checkbox.
- Share redaction helpers via `config_secrets.py` (also used by `/api/admin/export-config`) and document the canonical backup flow in `INSTALLATION.md`.

## Export behavior

**Default (safe) export includes:**
- `integrations` and `settings` with secret fields as `***`
- `media_users` identities, Trakt link metadata, and source settings
- `oauth_tokens` structure with redacted token values when tokens exist

**Full backup (`include_secrets=true`):**
- Live credentials and Trakt OAuth tokens
- Warning in API response and UI toast

Import merges redacted snapshots without overwriting existing secrets. Config schema version remains `2`.

## Test plan

- [x] `pytest api_service/test/test_config.py -k "export or import_preserves"`
- [x] Default export redacts integration secrets and Trakt OAuth tokens
- [x] Full backup roundtrip restores media users and OAuth tokens
- [x] Importing a safe snapshot preserves existing secrets on the target instance
- [x] Non-admin users receive 403 on `/api/config/export`
- [x] Manual homelab verification of Dashboard export modal

Made with [Cursor](https://cursor.com)