### PR TITLE
feat: add Trakt recommendations automation job

### DIFF
--- a/api_service/app.py
+++ b/api_service/app.py
@@ -207,6 +207,7 @@ try:
     from api_service.jobs.job_manager import JobManager
     from api_service.jobs.discover_automation import execute_discover_job
     from api_service.jobs.recommendation_automation import execute_recommendation_job
+    from api_service.jobs.trakt_recommendations_automation import execute_trakt_recommendations_job
     from api_service.jobs.system_job_sync import sync_system_job_from_config
     from api_service.jobs.queue_worker import run_queue_worker
 
@@ -231,6 +232,7 @@ try:
     # Register executors for both job types
     job_manager.set_job_executor(execute_discover_job, job_type='discover')
     job_manager.set_job_executor(execute_recommendation_job, job_type='recommendation')
+    job_manager.set_job_executor(execute_trakt_recommendations_job, job_type='trakt_recommendations')
     job_manager.start()
     job_manager.sync_jobs_from_db()
 
@@ -268,7 +270,7 @@ try:
         max_instances=1,
         replace_existing=True,
     )
-    logger.info("Jobs scheduler initialized (discover + recommendation + queue_worker + cleanup)")
+    logger.info("Jobs scheduler initialized (discover + recommendation + trakt_recommendations + queue_worker + cleanup)")
 except Exception as e:
     import traceback
     logger.error(f"Failed to initialize discover jobs scheduler: {e}")

--- a/api_service/blueprints/jobs/routes.py
+++ b/api_service/blueprints/jobs/routes.py
@@ -13,6 +13,10 @@ from api_service.db.job_repository import JobRepository
 from api_service.jobs.job_manager import JobManager
 from api_service.jobs.discover_automation import DiscoverAutomation, execute_discover_job
 from api_service.jobs.recommendation_automation import RecommendationAutomation, execute_recommendation_job
+from api_service.jobs.trakt_recommendations_automation import (
+    TraktRecommendationsAutomation,
+    execute_trakt_recommendations_job,
+)
 from api_service.utils.asyncio_loop import run_coroutine_sync
 
 logger = LoggerManager.get_logger("JobsRoute")
@@ -44,6 +48,8 @@ def get_job_manager() -> JobManager:
         manager.set_job_executor(execute_discover_job, job_type='discover')
     if 'recommendation' not in manager._job_executors:
         manager.set_job_executor(execute_recommendation_job, job_type='recommendation')
+    if 'trakt_recommendations' not in manager._job_executors:
+        manager.set_job_executor(execute_trakt_recommendations_job, job_type='trakt_recommendations')
     return manager
 
 
@@ -165,10 +171,10 @@ def create_job():
 
         # Set default job_type
         job_type = data.get('job_type', 'discover')
-        if job_type not in ['discover', 'recommendation']:
+        if job_type not in ['discover', 'recommendation', 'trakt_recommendations']:
             return jsonify({
                 'status': 'error',
-                'message': 'job_type must be "discover" or "recommendation"'
+                'message': 'job_type must be one of: discover, recommendation, trakt_recommendations'
             }), 400
         data['job_type'] = job_type
         
@@ -186,6 +192,12 @@ def create_job():
             return jsonify({
                 'status': 'error',
                 'message': f'media_type must be one of: {", ".join(valid_media_types)}'
+            }), 400
+
+        if job_type == 'trakt_recommendations' and len(data.get('user_ids') or []) != 1:
+            return jsonify({
+                'status': 'error',
+                'message': 'Trakt recommendations jobs require exactly one linked media user'
             }), 400
 
         # Validate schedule_type
@@ -247,14 +259,29 @@ def update_job(job_id: int):
             if existing.get('owner_id') != user_id:
                 return jsonify({'status': 'error', 'message': 'Insufficient permissions'}), 403
 
-        # Validate media_type if provided
+        # Validate job_type if provided
         job_type = data.get('job_type', existing.get('job_type', 'discover'))
+        if 'job_type' in data and job_type not in ['discover', 'recommendation', 'trakt_recommendations']:
+            return jsonify({
+                'status': 'error',
+                'message': 'job_type must be one of: discover, recommendation, trakt_recommendations'
+            }), 400
+
+        # Validate media_type if provided
         valid_media_types = ['movie', 'tv'] if job_type == 'discover' else ['movie', 'tv', 'both']
         if 'media_type' in data and data['media_type'] not in valid_media_types:
             return jsonify({
                 'status': 'error',
                 'message': f'media_type must be one of: {", ".join(valid_media_types)}'
             }), 400
+
+        if job_type == 'trakt_recommendations':
+            user_ids = data.get('user_ids', existing.get('user_ids') or [])
+            if len(user_ids) != 1:
+                return jsonify({
+                    'status': 'error',
+                    'message': 'Trakt recommendations jobs require exactly one linked media user'
+                }), 400
 
         # Validate schedule_type if provided
         if 'schedule_type' in data and data['schedule_type'] not in ['preset', 'cron']:
@@ -442,6 +469,8 @@ def run_job_now(job_id: int):
         # Execute job based on type (async function called synchronously)
         if job_type == 'recommendation':
             result = run_async(execute_recommendation_job(job_id))
+        elif job_type == 'trakt_recommendations':
+            result = run_async(execute_trakt_recommendations_job(job_id))
         else:
             result = run_async(execute_discover_job(job_id))
 
@@ -502,6 +531,8 @@ def dry_run_job(job_id: int):
         async def _run():
             if job_type == 'recommendation':
                 automation = await RecommendationAutomation.create(job_id, dry_run=True)
+            elif job_type == 'trakt_recommendations':
+                automation = await TraktRecommendationsAutomation.create(job_id, dry_run=True)
             else:
                 automation = await DiscoverAutomation.create(job_id)
             return await automation.run(dry_run=True)
@@ -559,6 +590,8 @@ def _run_all_jobs_in_background():
                     continue
                 if job_type == 'recommendation':
                     run_async(execute_recommendation_job(job_id))
+                elif job_type == 'trakt_recommendations':
+                    run_async(execute_trakt_recommendations_job(job_id))
                 else:
                     run_async(execute_discover_job(job_id))
                 logger.info(f"Force run all: job {job_id} completed")

--- a/api_service/db/database_manager.py
+++ b/api_service/db/database_manager.py
@@ -1232,12 +1232,13 @@ class DatabaseManager:
     
         count_query = """
             SELECT 
-                COUNT(DISTINCT s.media_id) as total_sources,
+                COUNT(DISTINCT COALESCE(s.media_id, r.tmdb_source_id, '0')) as total_sources,
                 COUNT(r.tmdb_request_id) as total_requests
             FROM requests r
-            JOIN metadata m ON r.tmdb_request_id = m.media_id
-            JOIN metadata s ON r.tmdb_source_id = s.media_id
+            JOIN metadata m ON r.tmdb_request_id = m.media_id AND r.media_type = m.media_type
+            LEFT JOIN metadata s ON r.tmdb_source_id = s.media_id
             WHERE r.requested_by = 'SuggestArr'
+            AND COALESCE(r.tmdb_source_id, '') != 'ai_search'
         """
     
         total_sources = 0
@@ -1276,11 +1277,14 @@ class DatabaseManager:
             }
 
         order_by_clause = sort_mapping.get(sort_by, sort_mapping['date-desc'])
+
+        from api_service.services.request_sources import request_source_title_sql
+        source_title_expr = request_source_title_sql("r")
     
         query = f"""
             SELECT
-                COALESCE(s.media_id, '0') AS source_id,
-                COALESCE(s.title, 'LLM Recommendation') AS source_title,
+                COALESCE(s.media_id, r.tmdb_source_id, '0') AS source_id,
+                {source_title_expr} AS source_title,
                 s.overview AS source_overview,
                 s.release_date AS source_release_date, s.poster_path AS source_poster_path, s.rating as rating,
                 r.tmdb_request_id, r.media_type, r.requested_at, s.logo_path, s.backdrop_path,
@@ -1289,7 +1293,7 @@ class DatabaseManager:
                 m.logo_path, m.backdrop_path, r.is_anime, r.rationale,
                 r.user_id, u.user_name, r.source_origin
             FROM requests r
-            JOIN metadata m ON r.tmdb_request_id = m.media_id
+            JOIN metadata m ON r.tmdb_request_id = m.media_id AND r.media_type = m.media_type
             LEFT JOIN metadata s ON r.tmdb_source_id = s.media_id
             LEFT JOIN users u ON r.user_id = u.user_id
             WHERE r.requested_by = 'SuggestArr'
@@ -1331,7 +1335,7 @@ class DatabaseManager:
             else:
                 if requested_at > source_max_dates[source_id]:
                     source_max_dates[source_id] = requested_at
-    
+
             sources[source_id]["requests"].append({
                 "request_id": row[6],
                 "media_type": row[7],
@@ -1663,7 +1667,7 @@ class DatabaseManager:
         count_query = """
             SELECT COUNT(*)
             FROM requests r
-            JOIN metadata m ON r.tmdb_request_id = m.media_id
+            JOIN metadata m ON r.tmdb_request_id = m.media_id AND r.media_type = m.media_type
             WHERE r.requested_by = 'SuggestArr'
             AND r.tmdb_source_id = 'ai_search'
         """
@@ -1674,7 +1678,7 @@ class DatabaseManager:
                 m.title, m.overview, m.poster_path, m.release_date, m.rating,
                 m.backdrop_path, m.logo_path
             FROM requests r
-            JOIN metadata m ON r.tmdb_request_id = m.media_id
+            JOIN metadata m ON r.tmdb_request_id = m.media_id AND r.media_type = m.media_type
             WHERE r.requested_by = 'SuggestArr'
             AND r.tmdb_source_id = 'ai_search'
             ORDER BY {order_by_clause}

--- a/api_service/jobs/discover_automation.py
+++ b/api_service/jobs/discover_automation.py
@@ -12,6 +12,7 @@ from api_service.db.database_manager import DatabaseManager
 from api_service.db.job_repository import JobRepository
 from api_service.services.filter_normalization import normalize_filters
 from api_service.services.seer.seer_client import SeerClient
+from api_service.services.request_sources import DISCOVER_SOURCE
 from api_service.services.tmdb.tmdb_discover import TMDbDiscover
 
 
@@ -275,7 +276,12 @@ class DiscoverAutomation:
 
                 # Request the content
                 self.logger.info(f"Requesting {media_type}: {title} (ID: {tmdb_id})")
-                success = await self.seer_client.request_media(media_type, item, source=None, user=None)
+                success = await self.seer_client.request_media(
+                    media_type,
+                    item,
+                    source={"id": DISCOVER_SOURCE},
+                    user=None,
+                )
 
                 if success:
                     requested_count += 1

--- a/api_service/jobs/trakt_recommendations_automation.py
+++ b/api_service/jobs/trakt_recommendations_automation.py
@@ -1,0 +1,603 @@
+"""
+Trakt Recommendations Automation for executing trakt_recommendations jobs.
+Fetches personalized recommendations from Trakt and requests them via Seer.
+"""
+import traceback
+from typing import Any, Dict, List, Optional
+
+from api_service.config.logger_manager import LoggerManager
+from api_service.db.database_manager import DatabaseManager
+from api_service.db.job_repository import JobRepository
+from api_service.jobs.discover_automation import ExecutionResult
+from api_service.jobs.recommendation_automation import (
+    _resolve_honor_seer_discovery,
+    _resolve_year_range_filters,
+)
+from api_service.services.config_service import ConfigService
+from api_service.services.filter_normalization import normalize_filters
+from api_service.services.request_sources import TRAKT_RECOMMENDATIONS_SOURCE
+from api_service.services.seer.seer_client import SeerClient
+from api_service.services.trakt.media_user_augmentor import TraktAccountResolver
+from api_service.services.trakt.trakt_client import TraktClient
+from api_service.services.tmdb.tmdb_client import TMDbClient
+from api_service.utils.tmdb_images import tmdb_image_url
+
+
+class TraktRecommendationsAutomation:
+    """Automates fetching Trakt personalized recommendations and requesting via Seer."""
+
+    def __init__(self):
+        """Initialize with logger only. Use create() for full initialization."""
+        self.logger = LoggerManager.get_logger(self.__class__.__name__)
+        self.job_id: Optional[int] = None
+        self.job_data: Optional[Dict[str, Any]] = None
+        self.seer_client: Optional[SeerClient] = None
+        self.tmdb_client: Optional[TMDbClient] = None
+        self.trakt_client: Optional[TraktClient] = None
+        self.repository: Optional[JobRepository] = None
+        self.db_manager: Optional[DatabaseManager] = None
+        self.local_content: Dict[str, set[str]] = {}
+        self.seer_discovered_ids: set[str] = set()
+        self.env_vars: Dict[str, Any] = {}
+
+    @classmethod
+    async def create(cls, job_id: int, dry_run: bool = False) -> "TraktRecommendationsAutomation":
+        """Create and initialize TraktRecommendationsAutomation for a job.
+
+        Args:
+            job_id: ID of the trakt_recommendations job to execute.
+            dry_run: If True, skip request-cache sync during initialization.
+
+        Returns:
+            Initialized TraktRecommendationsAutomation instance.
+
+        Raises:
+            ValueError: If the job is missing or misconfigured.
+        """
+        instance = cls()
+        instance.job_id = job_id
+        instance.repository = JobRepository()
+        instance.db_manager = DatabaseManager()
+        instance.env_vars = ConfigService.get_runtime_config()
+
+        instance.job_data = instance.repository.get_job(job_id)
+        if not instance.job_data:
+            raise ValueError(f"Job not found: {job_id}")
+        if instance.job_data.get("job_type") != "trakt_recommendations":
+            raise ValueError(f"Job {job_id} is not a trakt_recommendations job")
+
+        instance.logger.info(
+            "Initializing TraktRecommendationsAutomation for job: %s",
+            instance.job_data["name"],
+        )
+        await instance._initialize_components(dry_run=dry_run)
+        instance.logger.info("TraktRecommendationsAutomation initialized successfully")
+        return instance
+
+    async def _initialize_components(self, dry_run: bool = False) -> None:
+        """Initialize Seer, Trakt, and TMDb clients from job configuration."""
+        job_filters = self.job_data.get("filters", {})
+        normalized_filters = normalize_filters(job_filters)
+
+        number_of_seasons = self.env_vars.get("FILTER_NUM_SEASONS") or "all"
+        request_first_season_only = job_filters.get("request_first_season_only")
+        if request_first_season_only is None:
+            request_first_season_only = self.env_vars.get("REQUEST_FIRST_SEASON_ONLY", False)
+
+        exclude_downloaded = job_filters.get("exclude_downloaded")
+        if exclude_downloaded is None:
+            exclude_downloaded = self.env_vars.get("EXCLUDE_DOWNLOADED", True)
+        exclude_requested = job_filters.get("exclude_requested")
+        if exclude_requested is None:
+            exclude_requested = self.env_vars.get("EXCLUDE_REQUESTED", True)
+
+        anime_profile_config = self.env_vars.get("SEER_ANIME_PROFILE_CONFIG", {})
+        if not isinstance(anime_profile_config, dict):
+            anime_profile_config = {}
+
+        self.seer_client = SeerClient(
+            self.env_vars["SEER_API_URL"],
+            self.env_vars["SEER_TOKEN"],
+            self.env_vars["SEER_USER_NAME"],
+            self.env_vars["SEER_USER_PSW"],
+            self.env_vars["SEER_SESSION_TOKEN"],
+            number_of_seasons,
+            exclude_downloaded,
+            exclude_requested,
+            anime_profile_config,
+            request_first_season_only,
+        )
+        if dry_run:
+            self.logger.info("Dry-run mode: skipping Seer request cache sync.")
+        else:
+            await self.seer_client.init()
+        self.local_content = await self._load_existing_content()
+        if _resolve_honor_seer_discovery(job_filters, self.env_vars):
+            self.seer_discovered_ids = self._get_seer_discovered_tmdb_ids()
+
+        self.trakt_client = self._build_trakt_client()
+
+        search_size = int(job_filters.get("search_size") or self.env_vars.get("SEARCH_SIZE") or 20)
+        tmdb_threshold = normalized_filters.get("min_rating")
+        if tmdb_threshold is None:
+            tmdb_threshold = int(self.env_vars.get("FILTER_TMDB_THRESHOLD") or 60)
+        if tmdb_threshold <= 10:
+            tmdb_threshold = int(tmdb_threshold * 10)
+        tmdb_min_votes = job_filters.get(
+            "vote_count_gte",
+            int(self.env_vars.get("FILTER_TMDB_MIN_VOTES") or 20),
+        )
+        include_no_ratings = job_filters.get("include_no_rating")
+        if include_no_ratings is None:
+            include_no_ratings = self.env_vars.get("FILTER_INCLUDE_NO_RATING", True) is True
+
+        filter_release_year, filter_release_year_to = _resolve_year_range_filters(
+            {**job_filters, **normalized_filters},
+            self.env_vars,
+        )
+
+        filter_language = []
+        if normalized_filters.get("language"):
+            filter_language = [normalized_filters["language"]]
+        elif self.env_vars.get("FILTER_LANGUAGE"):
+            filter_language = self.env_vars.get("FILTER_LANGUAGE", [])
+            if not isinstance(filter_language, list):
+                filter_language = []
+
+        filter_genre = job_filters.get("without_genres", [])
+        if not filter_genre:
+            filter_genre_raw = self.env_vars.get("FILTER_GENRES_EXCLUDE", [])
+            filter_genre = filter_genre_raw if isinstance(filter_genre_raw, list) else []
+
+        filter_region_provider = job_filters.get("watch_region") or self.env_vars.get(
+            "FILTER_REGION_PROVIDER"
+        )
+        filter_streaming_services = job_filters.get("with_watch_providers")
+        if not filter_streaming_services:
+            filter_streaming_raw = self.env_vars.get("FILTER_STREAMING_SERVICES", [])
+            filter_streaming_services = (
+                filter_streaming_raw if isinstance(filter_streaming_raw, list) else []
+            )
+
+        filter_min_runtime = job_filters.get("min_runtime")
+        if filter_min_runtime is None:
+            filter_min_runtime = self.env_vars.get("FILTER_MIN_RUNTIME")
+
+        rating_source = job_filters.get("rating_source", self.env_vars.get("FILTER_RATING_SOURCE", "tmdb"))
+        job_imdb_rating = job_filters.get("imdb_rating_gte")
+        if job_imdb_rating is not None:
+            imdb_threshold = int(float(job_imdb_rating) * 10)
+        else:
+            raw = self.env_vars.get("FILTER_IMDB_THRESHOLD")
+            imdb_threshold = int(raw) if raw is not None else None
+
+        job_imdb_min_votes = job_filters.get("imdb_min_votes")
+        imdb_min_votes = (
+            int(job_imdb_min_votes)
+            if job_imdb_min_votes is not None
+            else (
+                int(self.env_vars.get("FILTER_IMDB_MIN_VOTES"))
+                if self.env_vars.get("FILTER_IMDB_MIN_VOTES") is not None
+                else None
+            )
+        )
+
+        omdb_client = None
+        if rating_source in ("imdb", "both"):
+            omdb_api_key = self.env_vars.get("OMDB_API_KEY", "")
+            if omdb_api_key:
+                from api_service.services.omdb.omdb_client import OmdbClient
+
+                omdb_client = OmdbClient(omdb_api_key)
+
+        job_include_tvod = job_filters.get("include_tvod")
+        filter_include_tvod = (
+            bool(job_include_tvod)
+            if job_include_tvod is not None
+            else (self.env_vars.get("FILTER_INCLUDE_TVOD", False) is True)
+        )
+
+        self.tmdb_client = TMDbClient(
+            self.env_vars["TMDB_API_KEY"],
+            search_size,
+            tmdb_threshold,
+            tmdb_min_votes,
+            include_no_ratings,
+            filter_release_year,
+            filter_language,
+            filter_genre,
+            filter_region_provider,
+            filter_streaming_services,
+            filter_min_runtime,
+            rating_source=rating_source,
+            imdb_threshold=imdb_threshold,
+            imdb_min_votes=imdb_min_votes,
+            omdb_client=omdb_client,
+            include_tvod=filter_include_tvod,
+            filter_release_year_to=filter_release_year_to,
+        )
+
+    def _get_seer_discovered_tmdb_ids(self) -> set[str]:
+        """Return TMDb IDs discovered/requested directly in Seer."""
+        query = "SELECT DISTINCT tmdb_request_id FROM requests WHERE requested_by = 'Seer'"
+        try:
+            with self.db_manager.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(query)
+                return {str(row[0]) for row in cursor.fetchall()}
+        except Exception as exc:
+            self.logger.warning("Could not load Seer discovery IDs: %s", exc)
+            return set()
+
+    async def _load_existing_content(self) -> Dict[str, set[str]]:
+        """Load existing Plex/Jellyfin TMDB IDs for downloaded-content checks."""
+        provider = str(self.env_vars.get("SELECTED_SERVICE") or "").lower()
+        max_content = int(self.env_vars.get("MAX_CONTENT_CHECK") or self.env_vars.get("MAX_CONTENT") or 10)
+
+        if provider == "jellyfin":
+            from api_service.services.jellyfin.jellyfin_client import JellyfinClient
+
+            jellyfin_libraries_raw = self.env_vars.get("JELLYFIN_LIBRARIES")
+            jellyfin_libraries = jellyfin_libraries_raw if isinstance(jellyfin_libraries_raw, list) else []
+            client = JellyfinClient(
+                self.env_vars.get("JELLYFIN_API_URL"),
+                self.env_vars.get("JELLYFIN_TOKEN"),
+                max_content,
+                jellyfin_libraries,
+            )
+            try:
+                await client.init_existing_content()
+                return self._existing_content_to_sets(client.existing_content)
+            finally:
+                await client.close()
+
+        if provider == "plex":
+            from api_service.services.plex.plex_client import PlexClient, normalize_guid_provider_id
+
+            plex_libraries_raw = self.env_vars.get("PLEX_LIBRARIES")
+            plex_libraries = plex_libraries_raw if isinstance(plex_libraries_raw, list) else []
+            client = PlexClient(
+                api_url=self.env_vars.get("PLEX_API_URL"),
+                token=self.env_vars.get("PLEX_TOKEN"),
+                max_content=max_content,
+                library_ids=plex_libraries,
+            )
+            try:
+                await client.init_existing_content()
+                existing = self._existing_content_to_sets(client.existing_content)
+                return {
+                    media_type: {
+                        normalize_guid_provider_id(f"tmdb://{tmdb_id}", "tmdb") or str(tmdb_id)
+                        for tmdb_id in ids
+                    }
+                    for media_type, ids in existing.items()
+                }
+            finally:
+                await client.close()
+
+        return {}
+
+    @staticmethod
+    def _existing_content_to_sets(existing_content: Optional[Dict[str, Any]]) -> Dict[str, set[str]]:
+        """Normalize client existing-content maps into media-type keyed TMDB ID sets."""
+        content_sets: Dict[str, set[str]] = {}
+        if not existing_content:
+            return content_sets
+
+        for media_type, items in existing_content.items():
+            ids = set()
+            for item in items or []:
+                if isinstance(item, dict) and item.get("tmdb_id"):
+                    ids.add(str(item["tmdb_id"]))
+                elif item:
+                    ids.add(str(item))
+            if ids:
+                content_sets[media_type] = ids
+        return content_sets
+
+    def _build_trakt_client(self) -> TraktClient:
+        """Resolve the linked Trakt account for the configured media user."""
+        user_ids = self.job_data.get("user_ids") or []
+        if len(user_ids) != 1:
+            raise ValueError("Trakt recommendations job requires exactly one linked media user")
+
+        provider = str(self.env_vars.get("SELECTED_SERVICE") or "").lower()
+        external_user_id = str(user_ids[0])
+        identity = self.db_manager.get_media_user_identity(provider, external_user_id)
+        resolved = TraktAccountResolver(self.db_manager).resolve(identity["id"])
+        if not resolved:
+            raise ValueError(
+                f"Media user {external_user_id} has no connected Trakt account"
+            )
+
+        integrations = self.env_vars.get("integrations") or {}
+        trakt_cfg = integrations.get("trakt") if isinstance(integrations.get("trakt"), dict) else {}
+        client_id = str(self.env_vars.get("TRAKT_CLIENT_ID") or trakt_cfg.get("client_id") or "").strip()
+        client_secret = str(
+            self.env_vars.get("TRAKT_CLIENT_SECRET") or trakt_cfg.get("client_secret") or ""
+        ).strip()
+        if not client_id or not client_secret:
+            raise ValueError("Trakt app credentials are not configured")
+
+        return TraktClient(
+            client_id,
+            client_secret,
+            access_token=resolved.get("access_token", ""),
+            refresh_token=resolved.get("refresh_token", ""),
+            expires_at=resolved.get("expires_at"),
+            db=self.db_manager,
+            link_id=resolved["id"],
+            token_source=resolved.get("token_source", "manual_oauth"),
+        )
+
+    async def run(self, dry_run: bool = False) -> ExecutionResult:
+        """Execute the Trakt recommendations job.
+
+        Args:
+            dry_run: When True, simulate without enqueueing requests.
+
+        Returns:
+            ExecutionResult with execution details.
+        """
+        if not self.job_data:
+            return ExecutionResult(
+                success=False,
+                results_count=0,
+                requested_count=0,
+                error_message="Job not initialized",
+            )
+
+        self.logger.info(
+            "%sStarting trakt recommendations job: %s",
+            "[DRY RUN] " if dry_run else "",
+            self.job_data["name"],
+        )
+        exec_id = None if dry_run else self.repository.log_execution_start(self.job_id)
+
+        try:
+            from contextlib import AsyncExitStack
+
+            async with AsyncExitStack() as stack:
+                if self.seer_client:
+                    await stack.enter_async_context(self.seer_client)
+                if self.tmdb_client:
+                    await stack.enter_async_context(self.tmdb_client)
+                    if self.tmdb_client.omdb_client:
+                        await stack.enter_async_context(self.tmdb_client.omdb_client)
+                if self.trakt_client:
+                    await stack.enter_async_context(self.trakt_client)
+
+                results = await self.fetch_trakt_recommendations()
+            results_count = len(results)
+            self.logger.info("Fetched %d Trakt recommendations after filtering", results_count)
+
+            requested_count, dry_run_items = await self.filter_and_request(results, dry_run=dry_run)
+
+            if not dry_run:
+                self.repository.log_execution_end(
+                    exec_id=exec_id,
+                    status="completed",
+                    results_count=results_count,
+                    requested_count=requested_count,
+                )
+
+            return ExecutionResult(
+                success=True,
+                results_count=results_count,
+                requested_count=requested_count,
+                dry_run_items=dry_run_items,
+            )
+        except Exception as exc:
+            error_msg = str(exc) if str(exc) else type(exc).__name__
+            self.logger.error("Job failed: %s", error_msg)
+            self.logger.error("Traceback: %s", traceback.format_exc())
+
+            if not dry_run and exec_id is not None:
+                self.repository.log_execution_end(
+                    exec_id=exec_id,
+                    status="failed",
+                    results_count=0,
+                    requested_count=0,
+                    error_message=error_msg,
+                )
+
+            return ExecutionResult(
+                success=False,
+                results_count=0,
+                requested_count=0,
+                error_message=error_msg,
+            )
+
+    async def fetch_trakt_recommendations(self) -> List[Dict[str, Any]]:
+        """Fetch and filter Trakt recommendations for the configured media types."""
+        job_filters = self.job_data.get("filters", {})
+        media_type = self.job_data.get("media_type", "movie")
+        max_results = int(self.job_data.get("max_results") or 20)
+        fetch_limit = max(max_results * 3, max_results)
+
+        ignore_collected = bool(job_filters.get("ignore_collected", True))
+        ignore_watched = bool(job_filters.get("ignore_watched", True))
+
+        media_types = ["movie", "tv"] if media_type == "both" else [media_type]
+        per_type_limit = fetch_limit if len(media_types) == 1 else max(fetch_limit // 2, max_results)
+
+        raw_items: List[Dict[str, Any]] = []
+        for item_type in media_types:
+            trakt_items = await self.trakt_client.get_recommendations(
+                item_type,
+                limit=per_type_limit,
+                ignore_collected=ignore_collected,
+                ignore_watched=ignore_watched,
+            )
+            for item in trakt_items:
+                raw_items.append({**item, "media_type": item_type})
+
+        filtered: List[Dict[str, Any]] = []
+        for item in raw_items:
+            enriched = await self._enrich_and_filter_item(item)
+            if enriched:
+                filtered.append(enriched)
+            if len(filtered) >= max_results:
+                break
+        return filtered[:max_results]
+
+    async def _enrich_and_filter_item(self, item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Fetch TMDb metadata and apply configured quality filters."""
+        media_type = item["media_type"]
+        tmdb_id = int(item["tmdb_id"])
+
+        details = await self._fetch_tmdb_details(tmdb_id, media_type)
+        if not details:
+            self.logger.debug("Skipping %s: TMDb details unavailable", item.get("title"))
+            return None
+
+        filter_result = self.tmdb_client._apply_filters(details, media_type)
+        if not filter_result["passed"]:
+            return None
+
+        needs_detail_call = (
+            self.tmdb_client.filter_min_runtime
+            or self.tmdb_client.rating_source in ("imdb", "both")
+        )
+        if needs_detail_call:
+            extra = await self.tmdb_client._get_item_details(tmdb_id, media_type)
+            runtime = extra.get("runtime") if extra else None
+            imdb_id = extra.get("imdb_id") if extra else None
+
+            if self.tmdb_client.filter_min_runtime:
+                if runtime is None or runtime < self.tmdb_client.filter_min_runtime:
+                    return None
+
+            if self.tmdb_client.rating_source in ("imdb", "both") and self.tmdb_client.omdb_client:
+                if not imdb_id:
+                    if not self.tmdb_client.include_no_ratings:
+                        return None
+                else:
+                    imdb_data = await self.tmdb_client.omdb_client.get_rating(imdb_id)
+                    if not self.tmdb_client._apply_imdb_filter(imdb_data, details, media_type):
+                        return None
+
+        excluded, provider = await self.tmdb_client.get_watch_providers(tmdb_id, media_type)
+        if excluded:
+            self.logger.debug(
+                "Skipping %s: available on excluded streaming provider %s",
+                item.get("title"),
+                provider,
+            )
+            return None
+
+        return details
+
+    async def _fetch_tmdb_details(self, tmdb_id: int, media_type: str) -> Optional[Dict[str, Any]]:
+        """Load TMDb details for a recommendation item."""
+        url = f"{self.tmdb_client.tmdb_api_url}/{media_type}/{tmdb_id}"
+        params = {"api_key": self.tmdb_client.api_key}
+        try:
+            session = await self.tmdb_client._get_session()
+            async with session.get(url, params=params, timeout=self.tmdb_client.REQUEST_TIMEOUT) as response:
+                if response.status not in {200, 201}:
+                    return None
+                data = await response.json()
+        except Exception as exc:
+            self.logger.debug("TMDb details fetch failed for %s %s: %s", media_type, tmdb_id, exc)
+            return None
+
+        return {
+            "id": data.get("id", tmdb_id),
+            "title": data.get("title") or data.get("name") or "",
+            "vote_average": data.get("vote_average"),
+            "vote_count": data.get("vote_count"),
+            "rating": data.get("vote_average"),
+            "votes": data.get("vote_count"),
+            "genre_ids": [genre["id"] for genre in data.get("genres", []) if genre.get("id")],
+            "release_date": data.get("release_date") or data.get("first_air_date"),
+            "first_air_date": data.get("first_air_date"),
+            "original_language": data.get("original_language"),
+            "poster_path": tmdb_image_url(data.get("poster_path"), "w500"),
+            "backdrop_path": tmdb_image_url(data.get("backdrop_path"), "w1280"),
+            "overview": data.get("overview"),
+            "media_type": media_type,
+        }
+
+    async def filter_and_request(
+        self,
+        results: List[Dict[str, Any]],
+        dry_run: bool = False,
+    ):
+        """Filter discovered content and request via Seer."""
+        requested_count = 0
+        dry_run_items: Optional[List[Dict[str, Any]]] = [] if dry_run else None
+
+        for item in results:
+            media_type = item.get("media_type") or self.job_data.get("media_type", "movie")
+            tmdb_id = item["id"]
+            title = item.get("title") or item.get("name") or "Unknown"
+
+            try:
+                if self.db_manager.check_request_exists(media_type, str(tmdb_id)):
+                    continue
+
+                if str(tmdb_id) in self.seer_discovered_ids:
+                    continue
+
+                if await self.seer_client.check_already_downloaded(
+                    tmdb_id,
+                    media_type,
+                    self.local_content,
+                ):
+                    continue
+
+                if await self.seer_client.check_already_requested(tmdb_id, media_type):
+                    continue
+
+                if dry_run:
+                    dry_run_items.append(self._format_dry_run_item(media_type, item))
+                    requested_count += 1
+                    continue
+
+                success = await self.seer_client.request_media(
+                    media_type,
+                    item,
+                    source={"id": TRAKT_RECOMMENDATIONS_SOURCE},
+                    user=None,
+                )
+                if success:
+                    requested_count += 1
+            except Exception as exc:
+                self.logger.error("Error processing %s: %s", title, exc)
+                continue
+
+        return requested_count, dry_run_items
+
+    @staticmethod
+    def _format_dry_run_item(media_type: str, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize an item dict for dry-run output."""
+        return {
+            "tmdb_id": item.get("id"),
+            "media_type": media_type,
+            "title": item.get("title") or item.get("name"),
+            "release_date": item.get("release_date") or item.get("first_air_date"),
+            "poster_path": item.get("poster_path"),
+            "vote_average": item.get("vote_average"),
+            "vote_count": item.get("vote_count"),
+            "overview": item.get("overview"),
+        }
+
+
+async def execute_trakt_recommendations_job(job_id: int) -> ExecutionResult:
+    """Execute a trakt_recommendations job by ID."""
+    logger = LoggerManager.get_logger("TraktRecommendationsJobExecutor")
+    logger.info("Starting execution of trakt recommendations job: %s", job_id)
+
+    try:
+        automation = await TraktRecommendationsAutomation.create(job_id)
+        return await automation.run()
+    except Exception as exc:
+        logger.error("Failed to execute job %s: %s", job_id, exc)
+        logger.error("Traceback: %s", traceback.format_exc())
+        return ExecutionResult(
+            success=False,
+            results_count=0,
+            requested_count=0,
+            error_message=str(exc),
+        )

--- a/api_service/services/request_sources.py
+++ b/api_service/services/request_sources.py
@@ -1,0 +1,32 @@
+"""Canonical request-source tags for non-TMDb automation origins."""
+
+DISCOVER_SOURCE = "discover"
+TRAKT_RECOMMENDATIONS_SOURCE = "trakt_recommendations"
+
+REQUEST_SOURCE_LABELS = {
+    DISCOVER_SOURCE: "Discover",
+    TRAKT_RECOMMENDATIONS_SOURCE: "Trakt Recommendations",
+}
+
+
+def is_tmdb_metadata_source_id(source_id) -> bool:
+    """Return True when *source_id* should be stored in the metadata table."""
+    if source_id is None:
+        return False
+    text = str(source_id)
+    if text in REQUEST_SOURCE_LABELS or text == "ai_search":
+        return False
+    return text.isdigit()
+
+
+def request_source_title_sql(source_alias: str = "r") -> str:
+    """Build a SQL CASE expression for grouped request source titles."""
+    when_clauses = "\n                ".join(
+        f"WHEN {source_alias}.tmdb_source_id = '{tag}' THEN '{label}'"
+        for tag, label in REQUEST_SOURCE_LABELS.items()
+    )
+    return f"""CASE
+                WHEN s.title IS NOT NULL THEN s.title
+                {when_clauses}
+                ELSE 'LLM Recommendation'
+            END"""

--- a/api_service/services/seer/seer_client.py
+++ b/api_service/services/seer/seer_client.py
@@ -4,6 +4,7 @@ from typing import List, Set
 from api_service.services.http.base_client import BaseHTTPClient
 from api_service.config.logger_manager import LoggerManager
 from api_service.db.database_manager import DatabaseManager
+from api_service.services.request_sources import is_tmdb_metadata_source_id
 
 BATCH_SIZE = 20  # Number of requests fetched per batch
 HTTP_OK = {200, 201, 202}  # Include 202 Accepted for async operations
@@ -377,7 +378,7 @@ class SeerClient(BaseHTTPClient):
             db.save_metadata(media, media_type)
         except Exception:
             pass  # non-critical — metadata is display-only cache
-        if source:
+        if source and is_tmdb_metadata_source_id(source.get("id")):
             try:
                 db.save_metadata(source, media_type)
             except Exception:

--- a/api_service/services/trakt/trakt_client.py
+++ b/api_service/services/trakt/trakt_client.py
@@ -172,6 +172,42 @@ class TraktClient(BaseHTTPClient):
             "tv": self._normalize_watched_items(shows, "show"),
         }
 
+    async def get_recommendations(
+        self,
+        media_type: str,
+        *,
+        limit: int = 20,
+        ignore_collected: bool = False,
+        ignore_watched: bool = False,
+    ) -> list[dict[str, str]]:
+        """Fetch personalized Trakt recommendations for the authenticated user.
+
+        Args:
+            media_type: ``movie`` or ``tv``.
+            limit: Maximum number of recommendations to return.
+            ignore_collected: When True, omit items already in the user's collection.
+            ignore_watched: When True, omit items already marked watched.
+
+        Returns:
+            Normalized recommendation items with ``tmdb_id``, ``media_type``,
+            ``title``, and ``year`` keys.
+        """
+        if media_type not in ("movie", "tv"):
+            raise ValueError("media_type must be 'movie' or 'tv'")
+
+        path = "/recommendations/movies" if media_type == "movie" else "/recommendations/shows"
+        params: dict[str, Any] = {
+            "limit": max(1, min(int(limit), 100)),
+            "extended": "min",
+        }
+        if ignore_collected:
+            params["ignore_collected"] = "true"
+        if ignore_watched:
+            params["ignore_watched"] = "true"
+
+        payload = await self._request("GET", path, params=params, authenticated=True)
+        return self._normalize_recommendation_items(payload, media_type)
+
     async def _request(
         self,
         method: str,
@@ -316,6 +352,25 @@ class TraktClient(BaseHTTPClient):
             "title": title,
             "year": item.get("year"),
         }
+
+    def _normalize_recommendation_items(
+        self,
+        payload: list[dict[str, Any]],
+        media_type: str,
+    ) -> list[dict[str, str]]:
+        """Normalize Trakt recommendation payloads into TMDB-keyed items."""
+        items: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for entry in payload or []:
+            normalized = self._normalize_media_item(entry, media_type)
+            if not normalized:
+                continue
+            tmdb_id = normalized["tmdb_id"]
+            if tmdb_id in seen:
+                continue
+            seen.add(tmdb_id)
+            items.append(normalized)
+        return items
 
     @staticmethod
     def _normalize_watched_items(payload: list[dict[str, Any]], item_key: str) -> list[dict[str, str]]:

--- a/api_service/services/trakt/trakt_client.py
+++ b/api_service/services/trakt/trakt_client.py
@@ -203,10 +203,20 @@ class TraktClient(BaseHTTPClient):
         if ignore_collected:
             params["ignore_collected"] = "true"
         if ignore_watched:
-            params["ignore_watched"] = "true"
+            params["ignore_watchlisted"] = "true"
 
         payload = await self._request("GET", path, params=params, authenticated=True)
-        return self._normalize_recommendation_items(payload, media_type)
+        items = self._normalize_recommendation_items(payload, media_type)
+        if ignore_watched:
+            watched_ids = await self._get_watched_tmdb_ids(media_type)
+            items = [item for item in items if item["tmdb_id"] not in watched_ids]
+        return items
+
+    async def _get_watched_tmdb_ids(self, media_type: str) -> set[str]:
+        item_key = "movie" if media_type == "movie" else "show"
+        path = "/sync/watched/movies" if media_type == "movie" else "/sync/watched/shows"
+        payload = await self._request("GET", path, authenticated=True)
+        return {item["tmdb_id"] for item in self._normalize_watched_items(payload, item_key)}
 
     async def _request(
         self,

--- a/api_service/test/test_jobs_routes_validation.py
+++ b/api_service/test/test_jobs_routes_validation.py
@@ -1,0 +1,125 @@
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+from flask import Flask, g
+
+from api_service.auth.limiter import limiter
+from api_service.blueprints.jobs import routes as jobs_routes
+from api_service.jobs.discover_automation import ExecutionResult
+
+
+def _make_client(monkeypatch, existing_job=None):
+    repository = MagicMock()
+    repository.get_job.return_value = existing_job
+    repository.update_job.return_value = True
+    monkeypatch.setattr(jobs_routes, "JobRepository", MagicMock(return_value=repository))
+    monkeypatch.setattr(jobs_routes, "get_job_manager", MagicMock())
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["RATELIMIT_ENABLED"] = False
+    app.secret_key = "test-secret"
+
+    @app.before_request
+    def inject_admin():
+        g.current_user = {"id": "1", "username": "admin", "role": "admin"}
+
+    limiter.init_app(app)
+    app.register_blueprint(jobs_routes.jobs_bp, url_prefix="/api/jobs")
+    return app.test_client(), repository
+
+
+def test_update_job_rejects_invalid_job_type(monkeypatch):
+    existing = {
+        "id": 1,
+        "job_type": "discover",
+        "owner_id": 1,
+        "media_type": "movie",
+        "user_ids": [],
+    }
+    client, repository = _make_client(monkeypatch, existing_job=existing)
+
+    response = client.put("/api/jobs/1", json={"job_type": "invalid"})
+
+    assert response.status_code == 400
+    assert "job_type must be one of" in response.get_json()["message"]
+    repository.update_job.assert_not_called()
+
+
+def test_update_trakt_job_rejects_empty_user_ids(monkeypatch):
+    existing = {
+        "id": 2,
+        "job_type": "trakt_recommendations",
+        "owner_id": 1,
+        "media_type": "both",
+        "user_ids": ["plex-user-1"],
+    }
+    client, repository = _make_client(monkeypatch, existing_job=existing)
+
+    response = client.put("/api/jobs/2", json={"user_ids": []})
+
+    assert response.status_code == 400
+    assert "exactly one linked media user" in response.get_json()["message"]
+    repository.update_job.assert_not_called()
+
+
+def test_update_trakt_job_rejects_multiple_user_ids(monkeypatch):
+    existing = {
+        "id": 2,
+        "job_type": "trakt_recommendations",
+        "owner_id": 1,
+        "media_type": "both",
+        "user_ids": ["plex-user-1"],
+    }
+    client, repository = _make_client(monkeypatch, existing_job=existing)
+
+    response = client.put("/api/jobs/2", json={"user_ids": ["plex-user-1", "plex-user-2"]})
+
+    assert response.status_code == 400
+    assert "exactly one linked media user" in response.get_json()["message"]
+    repository.update_job.assert_not_called()
+
+
+def test_update_trakt_job_accepts_single_user_id(monkeypatch):
+    existing = {
+        "id": 2,
+        "job_type": "trakt_recommendations",
+        "owner_id": 1,
+        "media_type": "both",
+        "user_ids": ["plex-user-1"],
+        "enabled": True,
+    }
+    client, repository = _make_client(monkeypatch, existing_job=existing)
+    repository.get_job.side_effect = [existing, existing]
+
+    response = client.put("/api/jobs/2", json={"user_ids": ["plex-user-2"]})
+
+    assert response.status_code == 200
+    repository.update_job.assert_called_once_with(2, {"user_ids": ["plex-user-2"]})
+
+
+def test_dry_run_trakt_job_initializes_in_dry_run_mode(monkeypatch):
+    existing = {
+        "id": 2,
+        "job_type": "trakt_recommendations",
+        "owner_id": 1,
+        "media_type": "both",
+        "user_ids": ["plex-user-1"],
+    }
+    client, _repository = _make_client(monkeypatch, existing_job=existing)
+    automation = MagicMock()
+    automation.run = AsyncMock(return_value=ExecutionResult(
+        success=True,
+        results_count=0,
+        requested_count=0,
+        dry_run_items=[],
+    ))
+    create = AsyncMock(return_value=automation)
+    monkeypatch.setattr(jobs_routes.TraktRecommendationsAutomation, "create", create)
+    monkeypatch.setattr(jobs_routes, "run_async", lambda coro: asyncio.run(coro))
+
+    response = client.post("/api/jobs/2/dry-run")
+
+    assert response.status_code == 200
+    create.assert_awaited_once_with(2, dry_run=True)

--- a/api_service/test/test_request_sources.py
+++ b/api_service/test/test_request_sources.py
@@ -1,0 +1,22 @@
+"""Tests for request source tag helpers."""
+from api_service.services.request_sources import (
+    DISCOVER_SOURCE,
+    TRAKT_RECOMMENDATIONS_SOURCE,
+    is_tmdb_metadata_source_id,
+    request_source_title_sql,
+)
+
+
+def test_trakt_source_is_not_metadata_id():
+    assert is_tmdb_metadata_source_id(TRAKT_RECOMMENDATIONS_SOURCE) is False
+    assert is_tmdb_metadata_source_id(DISCOVER_SOURCE) is False
+    assert is_tmdb_metadata_source_id("27205") is True
+    assert is_tmdb_metadata_source_id("ai_search") is False
+
+
+def test_request_source_title_sql_includes_trakt_label():
+    sql = request_source_title_sql("r")
+    assert "trakt_recommendations" in sql
+    assert "Trakt Recommendations" in sql
+    assert "discover" in sql
+    assert "Discover" in sql

--- a/api_service/test/test_request_sources.py
+++ b/api_service/test/test_request_sources.py
@@ -1,4 +1,8 @@
 """Tests for request source tag helpers."""
+from unittest.mock import patch
+
+from api_service.db import database_manager as dm_mod
+from api_service.db.database_manager import DatabaseManager
 from api_service.services.request_sources import (
     DISCOVER_SOURCE,
     TRAKT_RECOMMENDATIONS_SOURCE,
@@ -20,3 +24,26 @@ def test_request_source_title_sql_includes_trakt_label():
     assert "Trakt Recommendations" in sql
     assert "discover" in sql
     assert "Discover" in sql
+
+
+def test_grouped_requests_labels_synthetic_sources(tmp_path):
+    db_file = str(tmp_path / "requests.db")
+    with (
+        patch.object(dm_mod, "DB_PATH", db_file),
+        patch("api_service.db.database_manager.load_env_vars", return_value={"DB_TYPE": "sqlite"}),
+    ):
+        DatabaseManager._instance = None
+        db = DatabaseManager()
+        db.save_metadata({"id": "101", "title": "Discover Request"}, "movie")
+        db.save_metadata({"id": "202", "title": "Trakt Request"}, "tv")
+        db.save_request("movie", "101", DISCOVER_SOURCE)
+        db.save_request("tv", "202", TRAKT_RECOMMENDATIONS_SOURCE)
+
+        result = db.get_all_requests_grouped_by_source(page=1, per_page=10)
+
+    DatabaseManager._instance = None
+
+    sources = {item["source_id"]: item for item in result["data"]}
+    assert result["total_sources"] == 2
+    assert sources[DISCOVER_SOURCE]["source_title"] == "Discover"
+    assert sources[TRAKT_RECOMMENDATIONS_SOURCE]["source_title"] == "Trakt Recommendations"

--- a/api_service/test/test_tmdb_images.py
+++ b/api_service/test/test_tmdb_images.py
@@ -1,0 +1,21 @@
+"""Tests for TMDB image URL normalization."""
+
+from api_service.utils.tmdb_images import tmdb_image_url
+
+
+def test_builds_poster_url_from_relative_path():
+    assert tmdb_image_url("/abc.jpg", "w500") == "https://image.tmdb.org/t/p/w500/abc.jpg"
+
+
+def test_builds_backdrop_url_from_relative_path():
+    assert tmdb_image_url("/bg.jpg", "w1280") == "https://image.tmdb.org/t/p/w1280/bg.jpg"
+
+
+def test_returns_absolute_url_unchanged():
+    url = "https://image.tmdb.org/t/p/w500/abc.jpg"
+    assert tmdb_image_url(url, "w500") == url
+
+
+def test_returns_none_for_empty_path():
+    assert tmdb_image_url(None, "w500") is None
+    assert tmdb_image_url("", "w500") is None

--- a/api_service/test/test_trakt_client.py
+++ b/api_service/test/test_trakt_client.py
@@ -286,6 +286,7 @@ async def test_get_recommendations_requests_trakt_endpoint():
         FakeResponse(200, [
             {"title": "Arrival", "year": 2016, "ids": {"tmdb": 329865}},
         ]),
+        FakeResponse(200, []),
     ])
     client = TraktClient("cid", "secret", "access", session=session)
 
@@ -303,8 +304,33 @@ async def test_get_recommendations_requests_trakt_endpoint():
         "limit": 15,
         "extended": "min",
         "ignore_collected": "true",
-        "ignore_watched": "true",
+        "ignore_watchlisted": "true",
     }
+
+
+@pytest.mark.asyncio
+async def test_get_recommendations_filters_watched_items_locally():
+    session = FakeSession([
+        FakeResponse(200, [
+            {"title": "Arrival", "year": 2016, "ids": {"tmdb": 329865}},
+            {"title": "Heat", "year": 1995, "ids": {"tmdb": 949}},
+        ]),
+        FakeResponse(200, [
+            {"movie": {"title": "Heat", "year": 1995, "ids": {"tmdb": 949}}},
+        ]),
+    ])
+    client = TraktClient("cid", "secret", "access", session=session)
+
+    result = await client.get_recommendations("movie", ignore_watched=True)
+
+    assert result == [{
+        "tmdb_id": "329865",
+        "media_type": "movie",
+        "title": "Arrival",
+        "year": 2016,
+    }]
+    assert session.calls[1][0] == "GET"
+    assert session.calls[1][1] == "https://api.trakt.tv/sync/watched/movies"
 
 
 @pytest.mark.asyncio

--- a/api_service/test/test_trakt_client.py
+++ b/api_service/test/test_trakt_client.py
@@ -262,6 +262,51 @@ def test_normalize_watched_items_includes_year():
     ]
 
 
+def test_normalize_recommendation_items_deduplicates_by_tmdb_id():
+    client = TraktClient("cid", "secret")
+    payload = [
+        {"title": "Inception", "year": 2010, "ids": {"tmdb": 27205}},
+        {"title": "Duplicate", "year": 2010, "ids": {"tmdb": 27205}},
+        {"title": "No TMDB"},
+    ]
+
+    normalized = client._normalize_recommendation_items(payload, "movie")
+
+    assert normalized == [{
+        "tmdb_id": "27205",
+        "media_type": "movie",
+        "title": "Inception",
+        "year": 2010,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_get_recommendations_requests_trakt_endpoint():
+    session = FakeSession([
+        FakeResponse(200, [
+            {"title": "Arrival", "year": 2016, "ids": {"tmdb": 329865}},
+        ]),
+    ])
+    client = TraktClient("cid", "secret", "access", session=session)
+
+    result = await client.get_recommendations(
+        "movie",
+        limit=15,
+        ignore_collected=True,
+        ignore_watched=True,
+    )
+
+    assert result[0]["tmdb_id"] == "329865"
+    assert session.calls[0][0] == "GET"
+    assert session.calls[0][1] == "https://api.trakt.tv/recommendations/movies"
+    assert session.calls[0][2]["params"] == {
+        "limit": 15,
+        "extended": "min",
+        "ignore_collected": "true",
+        "ignore_watched": "true",
+    }
+
+
 @pytest.mark.asyncio
 async def test_401_refreshes_once_and_retries():
     session = FakeSession([

--- a/api_service/test/test_trakt_recommendations_automation.py
+++ b/api_service/test/test_trakt_recommendations_automation.py
@@ -1,0 +1,204 @@
+"""Tests for Trakt recommendations job automation."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api_service.jobs.trakt_recommendations_automation import TraktRecommendationsAutomation
+
+
+@pytest.mark.asyncio
+async def test_fetch_trakt_recommendations_applies_max_results():
+    automation = TraktRecommendationsAutomation()
+    automation.job_data = {
+        "media_type": "movie",
+        "max_results": 2,
+        "filters": {"ignore_collected": True, "ignore_watched": True},
+    }
+    automation.trakt_client = AsyncMock()
+    automation.trakt_client.get_recommendations.return_value = [
+        {"tmdb_id": "1", "title": "One", "media_type": "movie"},
+        {"tmdb_id": "2", "title": "Two", "media_type": "movie"},
+        {"tmdb_id": "3", "title": "Three", "media_type": "movie"},
+    ]
+    automation._enrich_and_filter_item = AsyncMock(side_effect=lambda item: {
+        "id": int(item["tmdb_id"]),
+        "title": item["title"],
+        "media_type": item["media_type"],
+        "vote_average": 8.0,
+        "vote_count": 1000,
+    })
+
+    results = await automation.fetch_trakt_recommendations()
+
+    assert len(results) == 2
+    automation.trakt_client.get_recommendations.assert_awaited_once_with(
+        "movie",
+        limit=6,
+        ignore_collected=True,
+        ignore_watched=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_non_trakt_job():
+    with patch("api_service.jobs.trakt_recommendations_automation.JobRepository") as repo_cls:
+        repo = repo_cls.return_value
+        repo.get_job.return_value = {"id": 1, "job_type": "discover", "name": "Wrong"}
+
+        with pytest.raises(ValueError, match="not a trakt_recommendations job"):
+            await TraktRecommendationsAutomation.create(1)
+
+
+@pytest.mark.asyncio
+async def test_build_trakt_client_requires_single_linked_user():
+    automation = TraktRecommendationsAutomation()
+    automation.job_data = {"user_ids": []}
+    automation.env_vars = {"SELECTED_SERVICE": "jellyfin"}
+    automation.db_manager = MagicMock()
+
+    with pytest.raises(ValueError, match="exactly one linked media user"):
+        automation._build_trakt_client()
+
+
+@pytest.mark.asyncio
+async def test_fetch_tmdb_details_builds_full_image_urls():
+    automation = TraktRecommendationsAutomation()
+    automation.tmdb_client = MagicMock()
+    automation.tmdb_client.tmdb_api_url = "https://api.themoviedb.org/3"
+    automation.tmdb_client.api_key = "key"
+    automation.tmdb_client.REQUEST_TIMEOUT = 10
+
+    response = MagicMock()
+    response.status = 200
+    response.json = AsyncMock(return_value={
+        "id": 27205,
+        "title": "Inception",
+        "vote_average": 8.8,
+        "vote_count": 30000,
+        "poster_path": "/inception.jpg",
+        "backdrop_path": "/inception-bg.jpg",
+        "overview": "A dream within a dream.",
+        "release_date": "2010-07-16",
+        "genres": [{"id": 28}],
+        "original_language": "en",
+    })
+
+    class _Ctx:
+        async def __aenter__(self):
+            return response
+
+        async def __aexit__(self, *args):
+            return False
+
+    session = MagicMock()
+    session.get = MagicMock(return_value=_Ctx())
+    automation.tmdb_client._get_session = AsyncMock(return_value=session)
+
+    details = await automation._fetch_tmdb_details(27205, "movie")
+
+    assert details["poster_path"] == "https://image.tmdb.org/t/p/w500/inception.jpg"
+    assert details["backdrop_path"] == "https://image.tmdb.org/t/p/w1280/inception-bg.jpg"
+    assert details["rating"] == 8.8
+
+
+@pytest.mark.asyncio
+async def test_enrich_and_filter_item_skips_excluded_streaming_provider():
+    automation = TraktRecommendationsAutomation()
+    automation.tmdb_client = MagicMock()
+    automation.tmdb_client._apply_filters.return_value = {"passed": True}
+    automation.tmdb_client.filter_min_runtime = None
+    automation.tmdb_client.rating_source = "tmdb"
+    automation.tmdb_client.omdb_client = None
+    automation.tmdb_client.get_watch_providers = AsyncMock(return_value=(True, "Netflix"))
+
+    item = {"media_type": "movie", "tmdb_id": "1", "title": "Blocked"}
+    automation._fetch_tmdb_details = AsyncMock(return_value={
+        "id": 1,
+        "title": "Blocked",
+        "vote_average": 8.0,
+        "vote_count": 1000,
+    })
+
+    result = await automation._enrich_and_filter_item(item)
+
+    assert result is None
+    automation.tmdb_client.get_watch_providers.assert_awaited_once_with(1, "movie")
+
+
+@pytest.mark.asyncio
+async def test_filter_and_request_uses_local_content_for_downloaded_check():
+    automation = TraktRecommendationsAutomation()
+    automation.job_data = {"media_type": "movie"}
+    automation.local_content = {"movie": {"27205"}}
+    automation.db_manager = MagicMock()
+    automation.db_manager.check_request_exists.return_value = False
+    automation.seer_client = MagicMock()
+    automation.seer_client.check_already_downloaded = AsyncMock(return_value=True)
+    automation.seer_client.check_already_requested = AsyncMock(return_value=False)
+    automation.seer_client.request_media = AsyncMock(return_value=True)
+
+    requested_count, dry_run_items = await automation.filter_and_request([
+        {"id": 27205, "title": "Inception", "media_type": "movie"},
+    ])
+
+    assert requested_count == 0
+    assert dry_run_items is None
+    automation.seer_client.check_already_downloaded.assert_awaited_once_with(
+        27205,
+        "movie",
+        automation.local_content,
+    )
+    automation.seer_client.check_already_requested.assert_not_awaited()
+    automation.seer_client.request_media.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_initialize_components_skips_seer_cache_sync_in_dry_run():
+    automation = TraktRecommendationsAutomation()
+    automation.job_data = {"filters": {}, "media_type": "movie"}
+    automation.env_vars = {
+        "SEER_API_URL": "http://seer",
+        "SEER_TOKEN": "token",
+        "SEER_USER_NAME": "user",
+        "SEER_USER_PSW": "pass",
+        "SEER_SESSION_TOKEN": "session",
+        "TMDB_API_KEY": "tmdb",
+        "SELECTED_SERVICE": "jellyfin",
+    }
+    automation._load_existing_content = AsyncMock(return_value={})
+    automation._build_trakt_client = MagicMock(return_value=MagicMock())
+
+    with (
+        patch("api_service.jobs.trakt_recommendations_automation.SeerClient") as seer_cls,
+        patch("api_service.jobs.trakt_recommendations_automation.TMDbClient"),
+    ):
+        seer = seer_cls.return_value
+        seer.init = AsyncMock()
+
+        await automation._initialize_components(dry_run=True)
+
+    seer.init.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_filter_and_request_skips_seer_discovered_ids():
+    automation = TraktRecommendationsAutomation()
+    automation.job_data = {"media_type": "movie"}
+    automation.local_content = {}
+    automation.seer_discovered_ids = {"27205"}
+    automation.db_manager = MagicMock()
+    automation.db_manager.check_request_exists.return_value = False
+    automation.seer_client = MagicMock()
+    automation.seer_client.check_already_downloaded = AsyncMock(return_value=False)
+    automation.seer_client.check_already_requested = AsyncMock(return_value=False)
+    automation.seer_client.request_media = AsyncMock(return_value=True)
+
+    requested_count, dry_run_items = await automation.filter_and_request([
+        {"id": 27205, "title": "Inception", "media_type": "movie"},
+    ])
+
+    assert requested_count == 0
+    assert dry_run_items is None
+    automation.seer_client.check_already_downloaded.assert_not_awaited()
+    automation.seer_client.check_already_requested.assert_not_awaited()
+    automation.seer_client.request_media.assert_not_awaited()

--- a/api_service/utils/tmdb_images.py
+++ b/api_service/utils/tmdb_images.py
@@ -1,0 +1,28 @@
+"""Helpers for normalizing TMDB image paths to absolute URLs."""
+
+from typing import Optional
+
+TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p"
+
+
+def tmdb_image_url(path: Optional[str], size: str = "w500") -> Optional[str]:
+    """Return a full TMDB image URL for a poster/logo/backdrop path fragment.
+
+    Args:
+        path: TMDB path (e.g. ``/abc.jpg``) or an already-absolute URL.
+        size: TMDB size token (e.g. ``w500``, ``w1280``).
+
+    Returns:
+        Absolute URL, or ``None`` when *path* is empty.
+    """
+    if not path:
+        return None
+
+    text = str(path).strip()
+    if not text:
+        return None
+    if text.startswith("http://") or text.startswith("https://"):
+        return text
+    if not text.startswith("/"):
+        text = f"/{text}"
+    return f"{TMDB_IMAGE_BASE}/{size}{text}"

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --skip-plugins @vue/cli-plugin-eslint",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test \"src/**/*.test.js\"",
     "lint": "vue-cli-service lint",
     "lint:styles": "stylelint \"src/**/*.{vue,css}\" --allow-empty-input",
     "lint:styles:fix": "stylelint \"src/**/*.{vue,css}\" --fix --allow-empty-input",

--- a/client/src/assets/styles/requestsPage.css
+++ b/client/src/assets/styles/requestsPage.css
@@ -271,6 +271,33 @@
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.8);
 }
 
+.source-visual-backdrop {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.source-visual-icon {
+  font-size: 4rem;
+  color: var(--color-text-primary);
+  filter: drop-shadow(0 4px 12px var(--surface-overlay));
+  transition: transform 0.5s ease;
+}
+
+.content-card:hover .source-visual-icon {
+  transform: scale(1.08);
+}
+
+.source-visual-modal {
+  color: var(--color-text-primary);
+}
+
+.source-visual-modal .source-visual-icon {
+  font-size: 5rem;
+}
+
 .card-body {
   padding: 1.5rem;
 }

--- a/client/src/components/RequestsPage.vue
+++ b/client/src/components/RequestsPage.vue
@@ -136,17 +136,24 @@
                 <!-- Card Header with Backdrop -->
                 <div class="card-header" @click="openModal(source)">
                   <div class="backdrop-container">
-                    <img 
-                      v-if="source.backdrop_path" 
-                      :src="source.backdrop_path" 
+                    <img
+                      v-if="source.backdrop_path && !source.visual"
+                      :src="source.backdrop_path"
                       :alt="source.title"
                       class="backdrop-image" />
-                    
+                    <div
+                      v-else-if="source.visual"
+                      class="source-visual-backdrop"
+                      :class="source.visual.key"
+                      :style="{ background: source.visual.gradient }">
+                      <i :class="source.visual.icon" class="source-visual-icon"></i>
+                    </div>
+
                     <!-- Logo overlay -->
                     <div class="backdrop-overlay">
-                      <img 
-                        v-if="source.logo_path" 
-                        :src="source.logo_path" 
+                      <img
+                        v-if="source.logo_path && !source.visual"
+                        :src="source.logo_path"
                         alt="Logo"
                         class="content-logo" />
                       <h3 v-else class="content-title-overlay">{{ source.title }}</h3>
@@ -158,15 +165,15 @@
                 <div class="card-body">
                   <!-- Badges -->
                   <div class="badge-container">
-                    <span class="badge badge-media">
+                    <span v-if="shouldShowSourceMediaBadge(source)" class="badge badge-media">
                       <i :class="source.media_type === 'movie' ? 'fas fa-film' : 'fas fa-tv'"></i>
                       {{ source.media_type.toUpperCase() }}
                     </span>
-                    <span class="badge badge-rating">
+                    <span v-if="!source.visual" class="badge badge-rating">
                       <i class="fas fa-star"></i>
                       {{ source.rating || 'N/A' }}
                     </span>
-                    <span class="badge badge-date">
+                    <span v-if="!source.visual && source.release_date" class="badge badge-date">
                       <i class="fas fa-calendar"></i>
                       {{ source.release_date }}
                     </span>
@@ -365,11 +372,18 @@
             <div class="modal-layout">
               <!-- Left: Poster -->
               <div class="modal-poster-section">
-                <img 
-                  v-if="selectedSource.poster_path" 
-                  :src="selectedSource.poster_path" 
+                <img
+                  v-if="selectedSource.poster_path && !getSourceVisual(selectedSource)"
+                  :src="selectedSource.poster_path"
                   :alt="selectedSource.title"
                   class="modal-poster" />
+                <div
+                  v-else-if="getSourceVisual(selectedSource)"
+                  class="modal-poster-placeholder source-visual-modal"
+                  :class="getSourceVisual(selectedSource).key"
+                  :style="{ background: getSourceVisual(selectedSource).gradient }">
+                  <i :class="getSourceVisual(selectedSource).icon" class="source-visual-icon"></i>
+                </div>
                 <div v-else class="modal-poster-placeholder">
                   <i class="fas fa-image text-6xl"></i>
                 </div>
@@ -482,6 +496,7 @@ import { useBackgroundImage } from '@/composables/useBackgroundImage';
 import Footer from './AppFooter.vue';
 import BaseDropdown from '@/components/common/BaseDropdown.vue';
 import { formatDate } from '@/utils/dateUtils.js';
+import { getRequestSourceVisual } from '@/utils/jobTypeVisuals.js';
 import { getAiSearchRequests } from '@/api/api.js';
 
 export default {
@@ -568,12 +583,20 @@ export default {
       const query = this.searchQuery.toLowerCase();
       let filtered = this.sources;
 
-      // Filter by media type
       if (this.mediaTypeFilter !== 'all') {
-        filtered = filtered.filter(source => source.media_type === this.mediaTypeFilter);
+        filtered = filtered
+          .map((source) => {
+            const matchingRequests = source.requests.filter(
+              (request) => request.media_type === this.mediaTypeFilter
+            );
+            if (matchingRequests.length === 0) {
+              return null;
+            }
+            return { ...source, requests: matchingRequests };
+          })
+          .filter(Boolean);
       }
 
-      // Filter by search query
       if (query) {
         filtered = filtered.filter((source) => {
           const sourceMatch = source.title && source.title.toLowerCase().includes(query);
@@ -657,6 +680,25 @@ export default {
   },
   methods: {
     formatDate,
+
+    getSourceVisual(source) {
+      return source?.visual ?? getRequestSourceVisual(source);
+    },
+
+    shouldShowSourceMediaBadge(source) {
+      if (!source?.media_type) {
+        return false;
+      }
+      if (source.visual && this.sourceHasMixedMediaTypes(source)) {
+        return false;
+      }
+      return true;
+    },
+
+    sourceHasMixedMediaTypes(source) {
+      const types = new Set((source?.requests || []).map((request) => request.media_type));
+      return types.size > 1;
+    },
 
     resetAndReload() {
       console.log('🔄 Sorting changed, reloading data...');
@@ -818,6 +860,10 @@ export default {
           showRequests: false,
           logo_path: sourceData.logo_path,
           backdrop_path: sourceData.backdrop_path,
+          visual: getRequestSourceVisual({
+            id: sourceData.source_id,
+            title: sourceData.source_title,
+          }),
           requests: sourceData.requests.map((request) => ({
             request_id: request.request_id,
             title: request.title,

--- a/client/src/components/settings/SettingsJobs.vue
+++ b/client/src/components/settings/SettingsJobs.vue
@@ -46,7 +46,7 @@
         <i class="fas fa-info-circle"></i>
       </div>
       <div class="info-content">
-        <h4>Two Types of Jobs</h4>
+        <h4>Job Types</h4>
         <div class="job-types-explanation">
           <div class="job-type-item">
             <span class="job-type-badge discover"><i class="fas fa-search"></i> Discover</span>
@@ -55,6 +55,10 @@
           <div class="job-type-item">
             <span class="job-type-badge recommendation"><i class="fas fa-users"></i> Recommendation</span>
             <span>Find similar content based on what your users have watched - like the original SuggestArr automation.</span>
+          </div>
+          <div class="job-type-item">
+            <span class="job-type-badge trakt_recommendations"><i class="fab fa-trakt"></i> Trakt</span>
+            <span>Fetch personalized movie and show recommendations from a linked Trakt.tv account.</span>
           </div>
         </div>
       </div>
@@ -108,8 +112,8 @@
               <h3>{{ job.name }}</h3>
               <div class="job-badges">
                 <span class="job-type-badge" :class="job.job_type || 'discover'">
-                  <i :class="job.job_type === 'recommendation' ? 'fas fa-users' : 'fas fa-search'"></i>
-                  {{ job.job_type === 'recommendation' ? 'Recommendation' : 'Discover' }}
+                  <i :class="getJobTypeIcon(job.job_type)"></i>
+                  {{ getJobTypeLabel(job.job_type) }}
                 </span>
                 <span class="media-type-badge" :class="job.media_type">
                   <i :class="getMediaTypeIcon(job.media_type)"></i>
@@ -277,6 +281,7 @@ import JobModal from './jobs/JobModal.vue';
 import JobHistoryModal from './jobs/JobHistoryModal.vue';
 import DryRunResultModal from './jobs/DryRunResultModal.vue';
 import OnboardingTour from '@/components/OnboardingTour.vue';
+import { getJobTypeIcon as resolveJobTypeIcon, getJobTypeLabel as resolveJobTypeLabel } from '@/utils/jobTypeVisuals.js';
 
 const JOBS_TOUR_KEY = 'suggestarr_jobs_tour_done';
 // Index of the first step that targets elements inside the job modal
@@ -716,6 +721,14 @@ export default {
       return icons[status] || 'fas fa-question';
     },
 
+    getJobTypeIcon(jobType) {
+      return resolveJobTypeIcon(jobType);
+    },
+
+    getJobTypeLabel(jobType) {
+      return resolveJobTypeLabel(jobType);
+    },
+
     getMediaTypeIcon(mediaType) {
       const icons = {
         movie: 'fas fa-film',
@@ -859,6 +872,11 @@ export default {
 .job-type-badge.recommendation {
   background: rgba(168, 85, 247, 0.15);
   color: #c084fc;
+}
+
+.job-type-badge.trakt_recommendations {
+  background: var(--color-error-alpha-10);
+  color: var(--color-error-light);
 }
 
 /* Job Badges Container */

--- a/client/src/components/settings/SettingsJobs.vue
+++ b/client/src/components/settings/SettingsJobs.vue
@@ -40,7 +40,7 @@
       </div>
     </transition>
 
-    <!-- Info Box explaining both job types -->
+    <!-- Info Box explaining job types -->
     <div v-if="showInfoBox" class="info-box" data-tour-id="jobs-info-box">
       <div class="info-icon">
         <i class="fas fa-info-circle"></i>
@@ -327,8 +327,8 @@ export default {
         },
         {
           targetId: 'jobs-info-box',
-          title: 'Two Types of Jobs',
-          description: 'Discover Jobs search TMDb catalogs using filters (genre, rating, year) — completely independent from your users. Recommendation Jobs analyse watch history to suggest similar content.',
+          title: 'Job Types',
+          description: 'Discover jobs search TMDb catalogs using filters. Recommendation jobs analyse media-user watch history. Trakt jobs fetch personalized recommendations from linked Trakt.tv accounts.',
           position: 'bottom'
         },
         {
@@ -340,7 +340,7 @@ export default {
         {
           targetId: 'jobs-first-card',
           title: 'Job Card',
-          description: 'Each card summarises a job: its type badge (Discover or Recommendation), media target, and whether it is currently active.',
+          description: 'Each card summarises a job: its type badge, media target, and whether it is currently active.',
           position: 'bottom'
         },
         {
@@ -364,7 +364,7 @@ export default {
         {
           targetId: 'job-modal-type-selector',
           title: 'Job Type',
-          description: 'Choose Discover to find new content via TMDb filters, or Recommendation to suggest titles based on what your users have already watched.',
+          description: 'Choose Discover for TMDb filter searches, Recommendation for watch-history suggestions, or Trakt for linked-account recommendations.',
           position: 'bottom'
         },
         {

--- a/client/src/components/settings/jobs/JobFilters.vue
+++ b/client/src/components/settings/jobs/JobFilters.vue
@@ -112,8 +112,8 @@
       <small class="form-help">Also include content that doesn't have any rating data yet</small>
     </div>
 
-    <!-- Minimum Seasons Filter (TV only) -->
-    <div v-if="mediaType === 'tv'" class="form-group">
+    <!-- Minimum Seasons Filter (TV only, discover/recommendation) -->
+    <div v-if="mediaType === 'tv' && jobType !== 'trakt_recommendations'" class="form-group">
       <label for="minSeasons">Minimum Seasons: {{ localFilters.min_seasons || 1 }}</label>
       <input
         id="minSeasons"
@@ -248,8 +248,8 @@
       </p>
     </div>
 
-    <!-- Sort By -->
-    <div class="form-group dropdown-wrapper">
+    <!-- Sort By (discover jobs only) -->
+    <div v-if="jobType === 'discover'" class="form-group dropdown-wrapper">
       <BaseDropdown
         v-model="localFilters.sort_by"
         :options="sortOptions"
@@ -282,6 +282,10 @@ export default {
     mediaType: {
       type: String,
       default: 'movie'
+    },
+    jobType: {
+      type: String,
+      default: 'discover'
     }
   },
   emits: ['update:modelValue'],

--- a/client/src/components/settings/jobs/JobModal.vue
+++ b/client/src/components/settings/jobs/JobModal.vue
@@ -18,7 +18,7 @@
             <div class="job-type-selector">
               <button
                 type="button"
-                class="job-type-btn"
+                class="job-type-btn discover"
                 :class="{ active: form.job_type === 'discover' }"
                 @click="setJobType('discover')"
               >
@@ -30,7 +30,7 @@
               </button>
               <button
                 type="button"
-                class="job-type-btn"
+                class="job-type-btn recommendation"
                 :class="{ active: form.job_type === 'recommendation' }"
                 @click="setJobType('recommendation')"
               >
@@ -40,18 +40,34 @@
                   <span class="job-type-desc">Based on user watch history</span>
                 </div>
               </button>
+              <button
+                type="button"
+                class="job-type-btn trakt_recommendations"
+                :class="{
+                  active: form.job_type === 'trakt_recommendations',
+                  disabled: !traktJobAvailable
+                }"
+                :disabled="!traktJobAvailable"
+                :title="traktJobUnavailableReason"
+                @click="setJobType('trakt_recommendations')"
+              >
+                <i class="fab fa-trakt"></i>
+                <div class="job-type-info">
+                  <span class="job-type-name">Trakt Recommendations</span>
+                  <span class="job-type-desc">Personalized lists from Trakt.tv</span>
+                </div>
+              </button>
+            </div>
+            <div v-if="!traktJobAvailable" class="trakt-setup-alert" role="status">
+              <i class="fas fa-circle-info"></i>
+              <span>{{ traktJobUnavailableReason }}</span>
             </div>
           </div>
 
           <!-- Info Note based on job type -->
           <div class="info-note" :class="form.job_type">
-            <i :class="form.job_type === 'discover' ? 'fas fa-search' : 'fas fa-history'"></i>
-            <span v-if="form.job_type === 'discover'">
-              Discover Jobs find content using TMDb filters, independent from user watch history.
-            </span>
-            <span v-else>
-              Recommendation Jobs find similar content based on what your users have watched.
-            </span>
+            <i :class="jobTypeInfoIcon"></i>
+            <span>{{ jobTypeInfoText }}</span>
           </div>
 
           <!-- Basic Info -->
@@ -64,7 +80,7 @@
                 id="jobName"
                 v-model="form.name"
                 type="text"
-                :placeholder="form.job_type === 'discover' ? 'e.g., Popular Movies 2024' : 'e.g., Weekly Recommendations'"
+                :placeholder="jobNamePlaceholder"
                 class="form-control"
                 required
               />
@@ -92,7 +108,7 @@
                   TV Shows
                 </button>
                 <button
-                  v-if="form.job_type === 'recommendation'"
+                  v-if="form.job_type !== 'discover'"
                   type="button"
                   class="media-type-btn"
                   :class="{ active: form.media_type === 'both' }"
@@ -109,6 +125,17 @@
           <div v-if="form.job_type === 'recommendation'" class="settings-group">
             <h4>Users to Monitor</h4>
             <RecommendationFilters v-model="form" :show-advanced="showAdvanced" :llm-configured="llmConfigured" />
+          </div>
+
+          <div v-if="form.job_type === 'trakt_recommendations'" class="settings-group">
+            <h4>Trakt User</h4>
+            <TraktRecommendationFilters
+              v-model="form"
+              :show-advanced="showAdvanced"
+              :trakt-configured="traktConfigured"
+              :connected-users="connectedUsers"
+              :is-loading="traktLoading"
+            />
           </div>
 
           <!-- Schedule -->
@@ -137,7 +164,7 @@
           <transition name="slide">
             <div v-if="showAdvanced" class="advanced-section">
               <!-- Max Results -->
-              <div v-if="form.job_type === 'discover'" class="settings-group" data-tour-id="job-modal-max-results">
+              <div v-if="form.job_type !== 'recommendation'" class="settings-group" data-tour-id="job-modal-max-results">
                 <h4>Results</h4>
                 <div class="form-group">
                   <label for="maxResults">Max Results: {{ form.max_results }}</label>
@@ -159,7 +186,11 @@
               <!-- Filters -->
               <div class="settings-group filters-section" data-tour-id="job-modal-filters">
                 <h4>{{ form.job_type === 'discover' ? 'Discovery Filters' : 'Quality Filters' }}</h4>
-                <JobFilters v-model="form.filters" :media-type="form.media_type" />
+                <JobFilters
+                  v-model="form.filters"
+                  :media-type="form.media_type"
+                  :job-type="form.job_type"
+                />
               </div>
 
               <!-- Spacer for dropdown overflow -->
@@ -188,14 +219,20 @@
 <script>
 import JobFilters from './JobFilters.vue';
 import RecommendationFilters from './RecommendationFilters.vue';
+import TraktRecommendationFilters from './TraktRecommendationFilters.vue';
 import SchedulePicker from './SchedulePicker.vue';
 import { jobsApi } from '@/api/jobsApi';
+import { listTraktMediaUsers } from '@/api/api';
+import { waitForAuthReady } from '@/composables/useAuth';
+import { getJobTypeIcon } from '@/utils/jobTypeVisuals.js';
+import axios from 'axios';
 
 export default {
   name: 'JobModal',
   components: {
     JobFilters,
     RecommendationFilters,
+    TraktRecommendationFilters,
     SchedulePicker
   },
   props: {
@@ -207,6 +244,7 @@ export default {
   emits: ['close', 'save'],
   data() {
     return {
+      connectedUsers: [],
       form: {
         name: '',
         job_type: 'discover',
@@ -223,15 +261,52 @@ export default {
       },
       isSaving: false,
       showAdvanced: false,
-      llmConfigured: false
+      llmConfigured: false,
+      traktConfigured: false,
+      traktLoading: false
     };
   },
   computed: {
     isEditing() {
       return this.job && this.job.id;
     },
+    traktJobAvailable() {
+      return this.traktConfigured && this.connectedUsers.length > 0;
+    },
+    traktJobUnavailableReason() {
+      if (!this.traktConfigured) {
+        return 'Configure Trakt app credentials in Services before creating a Trakt recommendations job.';
+      }
+      if (this.connectedUsers.length === 0) {
+        return 'Link at least one media user to Trakt in Services before creating a Trakt recommendations job.';
+      }
+      return '';
+    },
+    jobTypeInfoIcon() {
+      return getJobTypeIcon(this.form.job_type);
+    },
+    jobTypeInfoText() {
+      if (this.form.job_type === 'discover') {
+        return 'Discover Jobs find content using TMDb filters, independent from user watch history.';
+      }
+      if (this.form.job_type === 'trakt_recommendations') {
+        return 'Trakt Recommendations Jobs fetch personalized movie and show lists from a linked Trakt account.';
+      }
+      return 'Recommendation Jobs find similar content based on what your users have watched.';
+    },
+    jobNamePlaceholder() {
+      if (this.form.job_type === 'discover') return 'e.g., Popular Movies 2024';
+      if (this.form.job_type === 'trakt_recommendations') return 'e.g., Weekly Trakt Picks';
+      return 'e.g., Weekly Recommendations';
+    },
     isValid() {
-      return this.form.name.trim().length > 0 && this.form.media_type;
+      if (!this.form.name.trim().length || !this.form.media_type) {
+        return false;
+      }
+      if (this.form.job_type === 'trakt_recommendations') {
+        return (this.form.user_ids || []).length === 1;
+      }
+      return true;
     }
   },
   async mounted() {
@@ -278,19 +353,42 @@ export default {
     } catch {
       this.llmConfigured = false;
     }
+    await this.refreshTraktSetup();
   },
   methods: {
     openAdvanced() {
       this.showAdvanced = true;
     },
 
+    async refreshTraktSetup() {
+      this.traktLoading = true;
+      try {
+        await waitForAuthReady();
+        const statusResponse = await axios.get('/api/config/status');
+        this.traktConfigured = statusResponse.data?.trakt_app_configured === true;
+        if (!this.traktConfigured) {
+          this.connectedUsers = [];
+          return;
+        }
+        const traktRes = await listTraktMediaUsers();
+        this.connectedUsers = (traktRes.data?.media_users || [])
+          .filter((user) => user.trakt?.connected);
+      } catch {
+        this.traktConfigured = false;
+        this.connectedUsers = [];
+      } finally {
+        this.traktLoading = false;
+      }
+    },
+
     setJobType(jobType) {
+      if (jobType === 'trakt_recommendations' && !this.traktJobAvailable) {
+        return;
+      }
       this.form.job_type = jobType;
-      // Reset media_type if switching from recommendation to discover and 'both' was selected
       if (jobType === 'discover' && this.form.media_type === 'both') {
         this.form.media_type = 'movie';
       }
-      // Clear user_ids when switching to discover
       if (jobType === 'discover') {
         this.form.user_ids = [];
       }
@@ -360,6 +458,18 @@ export default {
   text-align: center;
 }
 
+.job-type-btn.discover > i {
+  color: var(--color-primary-light);
+}
+
+.job-type-btn.recommendation > i {
+  color: var(--color-warning-light);
+}
+
+.job-type-btn.trakt_recommendations > i {
+  color: var(--color-error-light);
+}
+
 .job-type-btn.active i {
   color: white;
 }
@@ -384,6 +494,36 @@ export default {
   color: rgba(255, 255, 255, 0.8);
 }
 
+.job-type-btn.disabled,
+.job-type-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.job-type-btn.disabled:hover,
+.job-type-btn:disabled:hover {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-color: var(--color-border-light);
+}
+
+.trakt-setup-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border: 1px dashed var(--color-border-light);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.trakt-setup-alert i {
+  color: var(--color-primary);
+  margin-top: 0.1rem;
+}
+
 /* Info Note */
 .info-note {
   display: flex;
@@ -399,6 +539,18 @@ export default {
 
 .info-note.recommendation {
   background: var(--color-bg-overlay-light);
+}
+
+.info-note.discover i {
+  color: var(--color-primary-light);
+}
+
+.info-note.recommendation i {
+  color: var(--color-warning-light);
+}
+
+.info-note.trakt_recommendations i {
+  color: var(--color-error-light);
 }
 
 .info-note i {

--- a/client/src/components/settings/jobs/TraktRecommendationFilters.vue
+++ b/client/src/components/settings/jobs/TraktRecommendationFilters.vue
@@ -1,0 +1,326 @@
+<template>
+  <div class="trakt-recommendation-filters">
+    <div class="form-group">
+      <label id="trakt-user-label">Trakt Account</label>
+      <p class="form-help">
+        Choose the media user whose linked Trakt recommendations this job should fetch.
+      </p>
+
+      <div v-if="isLoading" class="loading-users">
+        <i class="fas fa-spinner fa-spin"></i>
+        <span>Loading Trakt users...</span>
+      </div>
+
+      <div v-else-if="!traktConfigured" class="no-users">
+        <i class="fas fa-link-slash"></i>
+        <span>Configure Trakt app credentials in Services first.</span>
+      </div>
+
+      <div v-else-if="connectedUsers.length === 0" class="no-users">
+        <i class="fas fa-user-slash"></i>
+        <span>No media users have a linked Trakt account yet.</span>
+      </div>
+
+      <div
+        v-else
+        class="users-list"
+        role="radiogroup"
+        aria-labelledby="trakt-user-label"
+      >
+        <button
+          v-for="user in connectedUsers"
+          :key="user.external_user_id"
+          type="button"
+          class="user-item"
+          :class="{ selected: selectedUserId === user.external_user_id }"
+          role="radio"
+          :aria-checked="selectedUserId === user.external_user_id"
+          @click="selectUser(user.external_user_id)"
+        >
+          <div class="user-avatar">
+            <i class="fas fa-user"></i>
+          </div>
+          <div class="user-meta">
+            <span class="user-name">{{ user.external_username || user.external_user_id }}</span>
+            <span class="user-sub">Trakt connected</span>
+          </div>
+          <i v-if="selectedUserId === user.external_user_id" class="fas fa-check check-icon"></i>
+        </button>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>Request Behavior</label>
+      <div class="toggle-options">
+        <div class="toggle-item">
+          <BaseCheckbox v-model="localFilters.exclude_downloaded">
+            <span class="toggle-label-modal">
+              <i class="fas fa-download"></i>
+              Exclude downloaded content
+            </span>
+          </BaseCheckbox>
+        </div>
+        <small class="toggle-help">Skip titles already in your library</small>
+
+        <div class="toggle-item">
+          <BaseCheckbox v-model="localFilters.exclude_requested">
+            <span class="toggle-label-modal">
+              <i class="fas fa-clock"></i>
+              Exclude requested content
+            </span>
+          </BaseCheckbox>
+        </div>
+        <small class="toggle-help">Skip titles already requested in Seer</small>
+      </div>
+    </div>
+
+    <div v-if="showAdvanced" class="form-group">
+      <label for="maxTraktResults">Total Request Limit: {{ maxResults }}</label>
+      <input
+        id="maxTraktResults"
+        :value="maxResults"
+        type="range"
+        min="5"
+        max="100"
+        step="5"
+        class="form-range"
+        @input="updateMaxResults"
+      />
+      <small class="form-help">Maximum Trakt recommendations to request per run</small>
+    </div>
+  </div>
+</template>
+
+<script>
+import BaseCheckbox from '@/components/common/BaseCheckbox.vue';
+
+export default {
+  name: 'TraktRecommendationFilters',
+  components: { BaseCheckbox },
+  props: {
+    modelValue: {
+      type: Object,
+      default: () => ({})
+    },
+    showAdvanced: {
+      type: Boolean,
+      default: false
+    },
+    traktConfigured: {
+      type: Boolean,
+      default: false
+    },
+    connectedUsers: {
+      type: Array,
+      default: () => []
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return {
+      isUpdatingFromParent: false,
+      localFilters: {
+        exclude_downloaded: true,
+        exclude_requested: true
+      }
+    };
+  },
+  computed: {
+    selectedUserId() {
+      const ids = this.modelValue.user_ids || [];
+      return ids.length ? ids[0] : '';
+    },
+    maxResults() {
+      return this.modelValue.max_results || 20;
+    }
+  },
+  watch: {
+    modelValue: {
+      handler(newVal) {
+        this.isUpdatingFromParent = true;
+        this.localFilters = {
+          exclude_downloaded: newVal.filters?.exclude_downloaded ?? true,
+          exclude_requested: newVal.filters?.exclude_requested ?? true
+        };
+        this.$nextTick(() => {
+          this.isUpdatingFromParent = false;
+        });
+      },
+      deep: true,
+      immediate: true
+    },
+    localFilters: {
+      handler(newVal) {
+        if (!this.isUpdatingFromParent) {
+          this.updateFilters(newVal);
+        }
+      },
+      deep: true
+    },
+    connectedUsers: {
+      handler(users) {
+        if (!this.selectedUserId && users.length === 1) {
+          this.selectUser(users[0].external_user_id);
+        }
+      },
+      immediate: true
+    }
+  },
+  mounted() {
+    if (
+      this.modelValue.filters?.exclude_downloaded === undefined
+      || this.modelValue.filters?.exclude_requested === undefined
+    ) {
+      this.updateFilters(this.localFilters);
+    }
+  },
+  methods: {
+    selectUser(externalUserId) {
+      this.$emit('update:modelValue', {
+        ...this.modelValue,
+        user_ids: [externalUserId]
+      });
+    },
+    updateFilters(filters) {
+      this.$emit('update:modelValue', {
+        ...this.modelValue,
+        filters: {
+          ...this.modelValue.filters,
+          ...filters
+        }
+      });
+    },
+    updateMaxResults(event) {
+      this.$emit('update:modelValue', {
+        ...this.modelValue,
+        max_results: Number(event.target.value)
+      });
+    }
+  }
+};
+</script>
+
+<style scoped>
+.trakt-recommendation-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.trakt-recommendation-filters .form-help {
+  display: block;
+  margin-bottom: 0.75rem;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.users-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.user-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: var(--transition-base);
+}
+
+.user-item:hover {
+  background: var(--color-bg-overlay-light);
+}
+
+.user-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.user-item.selected {
+  border-color: var(--color-primary);
+  background: var(--color-primary-alpha-10);
+}
+
+.user-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-interactive);
+  color: var(--color-text-muted);
+}
+
+.user-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+}
+
+.user-name {
+  font-size: 0.85rem;
+  color: var(--color-text-primary);
+}
+
+.user-sub {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+
+.check-icon {
+  color: var(--color-primary);
+}
+
+.no-users,
+.loading-users {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border: 1px dashed var(--color-border-light);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.toggle-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.toggle-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.toggle-label-modal {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.toggle-help {
+  display: block;
+  margin: 0 0 0.5rem 1.75rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+</style>

--- a/client/src/utils/jobTypeVisuals.js
+++ b/client/src/utils/jobTypeVisuals.js
@@ -1,0 +1,89 @@
+/** Shared icons, labels, and colors for automation job types and system request sources. */
+
+export const JOB_TYPE_CONFIG = {
+  discover: {
+    icon: 'fas fa-search',
+    label: 'Discover',
+    color: 'var(--color-primary-light)',
+    gradient: 'linear-gradient(135deg, var(--color-info-hover) 0%, var(--color-info) 50%, var(--color-primary-light) 100%)',
+  },
+  recommendation: {
+    icon: 'fas fa-users',
+    label: 'Recommendation',
+    color: 'var(--color-warning-light)',
+    gradient: 'linear-gradient(135deg, var(--color-primary-dark) 0%, var(--color-primary) 50%, var(--color-warning-light) 100%)',
+  },
+  trakt_recommendations: {
+    icon: 'fab fa-trakt',
+    label: 'Trakt Recommendations',
+    color: 'var(--color-error-light)',
+    gradient: 'linear-gradient(135deg, var(--color-error-hover) 0%, var(--color-error) 50%, var(--color-error-light) 100%)',
+  },
+  llm_recommendation: {
+    icon: 'fas fa-robot',
+    label: 'LLM Recommendation',
+    color: 'var(--color-warning-light)',
+    gradient: 'linear-gradient(135deg, var(--color-primary-dark) 0%, var(--color-primary) 50%, var(--color-warning-light) 100%)',
+  },
+};
+
+/**
+ * @param {string} jobType
+ * @returns {typeof JOB_TYPE_CONFIG.discover}
+ */
+export function getJobTypeConfig(jobType) {
+  return JOB_TYPE_CONFIG[jobType] || JOB_TYPE_CONFIG.discover;
+}
+
+/**
+ * @param {string} jobType
+ * @returns {string}
+ */
+export function getJobTypeIcon(jobType) {
+  return getJobTypeConfig(jobType).icon;
+}
+
+/**
+ * @param {string} jobType
+ * @returns {string}
+ */
+export function getJobTypeLabel(jobType) {
+  const config = getJobTypeConfig(jobType);
+  if (jobType === 'trakt_recommendations') {
+    return 'Trakt';
+  }
+  return config.label;
+}
+
+/**
+ * Visual config for grouped request sources that are not TMDb titles.
+ *
+ * @param {{ id?: string|number, title?: string }|null|undefined} source
+ * @returns {(typeof JOB_TYPE_CONFIG.discover & { key: string })|null}
+ */
+export function getRequestSourceVisual(source) {
+  if (!source) {
+    return null;
+  }
+
+  const id = String(source.id ?? '');
+  if (id === 'discover') {
+    return { ...JOB_TYPE_CONFIG.discover, key: 'discover' };
+  }
+  if (id === 'trakt_recommendations') {
+    return { ...JOB_TYPE_CONFIG.trakt_recommendations, key: 'trakt_recommendations' };
+  }
+  if (id === '0') {
+    return { ...JOB_TYPE_CONFIG.llm_recommendation, key: 'llm_recommendation' };
+  }
+
+  return null;
+}
+
+/**
+ * @param {{ id?: string|number, title?: string }|null|undefined} source
+ * @returns {boolean}
+ */
+export function isSystemRequestSource(source) {
+  return getRequestSourceVisual(source) !== null;
+}

--- a/client/src/utils/jobTypeVisuals.test.js
+++ b/client/src/utils/jobTypeVisuals.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { getRequestSourceVisual } from './jobTypeVisuals.js';
+
+test('getRequestSourceVisual resolves synthetic source ids', () => {
+  assert.equal(getRequestSourceVisual({ id: 'discover' })?.key, 'discover');
+  assert.equal(getRequestSourceVisual({ id: 'trakt_recommendations' })?.key, 'trakt_recommendations');
+  assert.equal(getRequestSourceVisual({ id: '0' })?.key, 'llm_recommendation');
+});
+
+test('getRequestSourceVisual ignores title-only matches', () => {
+  assert.equal(getRequestSourceVisual({ title: 'Trakt Recommendations' }), null);
+  assert.equal(getRequestSourceVisual({ title: 'LLM Recommendation' }), null);
+  assert.equal(getRequestSourceVisual({ title: 'Discover' }), null);
+});


### PR DESCRIPTION
## Status

Ready for review, testing, and merge. This branch has been rebased onto the PR base (`upstream/nightly`) and deployed/tested on my homelab.

## Summary

- Adds a new `trakt_recommendations` job type that fetches personalized movie/show recommendations from a linked Trakt account, enriches them via TMDb quality filters, and requests matches through Seer.
- Introduces canonical request-source tags (`discover`, `trakt_recommendations`) so grouped request history and Seer metadata handling treat non-TMDb origins correctly.
- Extends the Jobs UI with a Trakt job type, linked-user selection, filters, and shared job/source visuals.
- Fixes request history grouping for system sources (Discover, Trakt, LLM) in the "By Watched Content" view.
- Fixes Trakt recommendation filtering so watched items are excluded locally and Trakt receives the documented `ignore_watchlisted` parameter.

## Test plan

- [x] Backend: `pytest api_service/test/test_trakt_client.py api_service/test/test_trakt_recommendations_automation.py api_service/test/test_jobs_routes_validation.py api_service/test/test_request_sources.py`
- [x] Frontend unit smoke: `cd client && npm test`
- [x] Frontend production build: `cd client && npm run build`
- [x] Create/run a Trakt recommendations job on homelab with Trakt app credentials + linked media user
- [x] Confirm requests are delivered to Seer and recorded with source label "Trakt Recommendations"
- [x] Check Request History / queue state after clearing duplicate local test history and rerunning

## Pull request checklist (from CONTRIBUTING.md)

- [x] Tests added/updated when applicable
- [x] Documentation updated when behavior or setup changed
- [x] No hardcoded styles introduced (design tokens / CSS variables used)

## Notes for reviewers

- Trakt recommendations are intentionally separate from per-user `trakt_sources` / watch-history augmentation used by Plex/Jellyfin recommendation jobs.
- The Vue production build currently emits existing CSS ordering and asset-size warnings, but exits successfully.

Made with [Cursor](https://cursor.com)