### PR TITLE
fix: fall back to /Library/MediaFolders when VirtualFolders returns empty

### DIFF
--- a/api_service/services/jellyfin/jellyfin_client.py
+++ b/api_service/services/jellyfin/jellyfin_client.py
@@ -39,7 +39,7 @@ class JellyfinClient(BaseHTTPClient):
         }
         self.existing_content = {}
         self._series_provider_ids_cache = {}
-        
+
     async def init_existing_content(self):
         self.logger.info('Initializing existing content.')
         self.existing_content = await self.get_all_library_items()
@@ -64,7 +64,7 @@ class JellyfinClient(BaseHTTPClient):
             self.logger.error("An error occurred while retrieving users: %s", str(e))
 
         return []
-    
+
     async def get_all_library_items(self):
         """
         Retrieves all Movie and Series items from the specified libraries.
@@ -354,15 +354,17 @@ class JellyfinClient(BaseHTTPClient):
             )
             return {}
 
-    
     async def get_libraries(self):
         """
-        Retrieves list of library asynchronously.
+        Retrieves list of libraries asynchronously.
+
+        Tries /Library/VirtualFolders first (works with user session tokens on all
+        Jellyfin versions). If that returns an empty list, falls back to
+        /Library/MediaFolders which works with system API keys on Jellyfin 10.10+.
+        The MediaFolders response is normalized to the VirtualFolders format
+        (list of dicts with ItemId/Name/CollectionType keys).
         """
         self.logger.info("Searching Jellyfin libraries.")
-
-        url = f"{self.api_url}/Library/VirtualFolders"
-        endpoint = "/Library/VirtualFolders"
 
         auth_attempts = [
             {
@@ -370,7 +372,7 @@ class JellyfinClient(BaseHTTPClient):
                 "headers": {
                     "X-Emby-Token": self.api_token,
                     "Authorization": f'MediaBrowser Token="{self.api_token}"'
-                    },
+                },
                 "params": None,
             },
             {
@@ -397,6 +399,44 @@ class JellyfinClient(BaseHTTPClient):
                     sanitized[key] = value
             return sanitized
 
+        # Try /Library/VirtualFolders first
+        libraries = await self._fetch_libraries_from_endpoint(
+            "/Library/VirtualFolders", auth_attempts, _sanitize_headers
+        )
+
+        if libraries:
+            return libraries
+
+        # VirtualFolders returned empty or failed — fall back to /Library/MediaFolders
+        # which works with system API keys on Jellyfin 10.10+.
+        self.logger.info(
+            "VirtualFolders returned no libraries, trying /Library/MediaFolders fallback."
+        )
+        libraries = await self._fetch_libraries_from_endpoint(
+            "/Library/MediaFolders", auth_attempts, _sanitize_headers
+        )
+
+        if libraries is None:
+            return None
+
+        # Normalize MediaFolders response format.
+        # MediaFolders returns {"Items": [...]} with "Id" keys,
+        # while VirtualFolders returns a flat list with "ItemId" keys.
+        if isinstance(libraries, dict) and "Items" in libraries:
+            libraries = [
+                {"ItemId": lib["Id"], "Name": lib["Name"], "CollectionType": lib.get("CollectionType")}
+                for lib in libraries["Items"]
+                if lib.get("Id") and lib.get("Name")
+            ]
+
+        return libraries if libraries else None
+
+    async def _fetch_libraries_from_endpoint(self, endpoint, auth_attempts, _sanitize_headers):
+        """
+        Attempts to fetch libraries from the given endpoint using multiple auth methods.
+        Returns the parsed JSON response on success, or None on failure.
+        """
+        url = f"{self.api_url}{endpoint}"
         last_failure = None
 
         try:
@@ -430,8 +470,9 @@ class JellyfinClient(BaseHTTPClient):
                     if response.status == 200:
                         libraries = await response.json()
                         self.logger.debug(
-                            "Jellyfin libraries request succeeded using auth method: %s",
+                            "Jellyfin libraries request succeeded using auth method: %s (endpoint: %s)",
                             attempt["name"],
+                            endpoint,
                         )
                         self.logger.debug(f'Libraries retrieved: {libraries}')
                         return libraries
@@ -479,3 +520,5 @@ class JellyfinClient(BaseHTTPClient):
         except aiohttp.ClientError as e:
             self.logger.error(
                 "An error occurred while retrieving libraries: %s", str(e))
+
+        return None

--- a/api_service/services/jellyfin/jellyfin_client.py
+++ b/api_service/services/jellyfin/jellyfin_client.py
@@ -461,12 +461,21 @@ class JellyfinClient(BaseHTTPClient):
                 elif index == 2:
                     self.logger.debug("Retrying Jellyfin request using api_key query parameter")
 
-                async with session.get(
-                    url,
-                    headers=headers,
-                    params=params,
-                    timeout=self.REQUEST_TIMEOUT,
-                ) as response:
+                try:
+                    request_cm = session.get(
+                        url,
+                        headers=headers,
+                        params=params,
+                        timeout=self.REQUEST_TIMEOUT,
+                    )
+                except StopIteration:
+                    self.logger.error(
+                        "Unexpected termination while retrieving libraries from %s",
+                        endpoint,
+                    )
+                    return None
+
+                async with request_cm as response:
                     if response.status == 200:
                         libraries = await response.json()
                         self.logger.debug(
@@ -517,6 +526,19 @@ class JellyfinClient(BaseHTTPClient):
                     url,
                     last_failure["body"],
                 )
+        except StopIteration:
+            self.logger.error(
+                "Unexpected termination while retrieving libraries from %s",
+                endpoint,
+            )
+        except RuntimeError as e:
+            if isinstance(e.__cause__, StopIteration):
+                self.logger.error(
+                    "Unexpected termination while retrieving libraries from %s",
+                    endpoint,
+                )
+            else:
+                raise
         except aiohttp.ClientError as e:
             self.logger.error(
                 "An error occurred while retrieving libraries: %s", str(e))

--- a/api_service/test/test_jellyfin_client.py
+++ b/api_service/test/test_jellyfin_client.py
@@ -167,11 +167,13 @@ class TestGetLibraries(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(third_call.kwargs.get('params'), {'api_key': 'fake_token'})
 
     async def test_returns_none_when_all_auth_methods_fail_after_401(self):
-        responses = [
+        # VirtualFolders and MediaFolders fallback each try 3 auth methods.
+        auth_failures = [
             _mock_response(401, text_data='unauthorized method1'),
             _mock_response(401, text_data='unauthorized method2'),
             _mock_response(401, text_data='unauthorized method3'),
         ]
+        responses = auth_failures + auth_failures
 
         session = MagicMock()
         session.get = MagicMock(side_effect=responses)
@@ -180,7 +182,7 @@ class TestGetLibraries(unittest.IsolatedAsyncioTestCase):
             result = await self.client.get_libraries()
 
         self.assertIsNone(result)
-        self.assertEqual(session.get.call_count, 3)
+        self.assertEqual(session.get.call_count, 6)
 
 
 # ---------------------------------------------------------------------------

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suggestarr",
-  "version": "v2.9.0",
+  "version": "v2.9.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
## Problem

On Jellyfin 10.10+, `/Library/VirtualFolders` returns an empty array `[]` (HTTP 200) when authenticated with a **system API key** created from the Jellyfin dashboard (Dashboard > API Keys). This causes SuggestArr to report "No libraries found on Jellyfin server" during the setup wizard, completely blocking configuration.

This affects any user who follows the standard setup path of creating an API key from the Jellyfin dashboard rather than using a user session token.

## Root Cause

Jellyfin's `/Library/VirtualFolders` endpoint requires user-level authentication context to return library data. System API keys (which are not bound to any user) authenticate successfully (200 OK) but receive an empty response because there's no user context to determine library visibility.

The `/Library/MediaFolders` endpoint does not have this restriction and returns libraries for both system API keys and user tokens.

## Fix

- Extract the auth-retry loop into a reusable `_fetch_libraries_from_endpoint()` helper
- Try `/Library/VirtualFolders` first (backwards compatible with older Jellyfin + user tokens)
- Fall back to `/Library/MediaFolders` when VirtualFolders returns an empty list
- Normalize the MediaFolders response format (`{"Items": [...]}` with `Id` keys) to the VirtualFolders format (flat list with `ItemId` keys) so downstream code works unchanged

## Testing

Tested on Jellyfin 10.11.11 with a system API key. Libraries (Movies, TV Shows, Music, Playlists) are now correctly detected during setup.