### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/api_service/config/config.py
+++ b/api_service/config/config.py
@@ -19,7 +19,8 @@ INTEGRATION_TO_FLAT: dict = {
     'seer':     {'api_url': 'SEER_API_URL', 'api_key': 'SEER_TOKEN',
                  'session_token': 'SEER_SESSION_TOKEN'},
     'omdb':     {'api_key': 'OMDB_API_KEY'},
-    'openai':   {'api_key': 'OPENAI_API_KEY', 'base_url': 'OPENAI_BASE_URL', 'model': 'LLM_MODEL'},
+    'openai':   {'api_key': 'OPENAI_API_KEY', 'base_url': 'OPENAI_BASE_URL', 'model': 'LLM_MODEL',
+                 'provider': 'LLM_PROVIDER'},
     'trakt':    {'client_id': 'TRAKT_CLIENT_ID', 'client_secret': 'TRAKT_CLIENT_SECRET'},
 }
 
@@ -215,6 +216,7 @@ def get_default_values():
         'OPENAI_API_KEY': lambda: '',
         'OPENAI_BASE_URL': lambda: '',
         'LLM_MODEL': lambda: 'gpt-4o-mini',
+        'LLM_PROVIDER': lambda: 'openai',
         'TRAKT_CLIENT_ID': lambda: '',
         'TRAKT_CLIENT_SECRET': lambda: '',
         'TRAKT_ACCESS_TOKEN': lambda: '',
@@ -342,7 +344,7 @@ def get_config_sections():
                      'ENABLE_STATIC_BACKGROUND', 'STATIC_BACKGROUND_COLOR',
                      'CACHE_TTL', 'MAX_CACHE_SIZE', 'API_TIMEOUT', 'API_RETRIES',
                      'ENABLE_API_CACHING', 'OPENAI_API_KEY', 'OPENAI_BASE_URL',
-                     'LLM_MODEL', 'SUBPATH', 'ALLOW_REGISTRATION',
+                     'LLM_MODEL', 'LLM_PROVIDER', 'SUBPATH', 'ALLOW_REGISTRATION',
                      'AUTH_MODE', 'AUTH_TRUSTED_CIDRS', 'AUTH_BYPASS_USERNAME']
     }
 

--- a/api_service/requirements.txt
+++ b/api_service/requirements.txt
@@ -31,3 +31,4 @@ mysql-connector-python==9.7.0
 psycopg2-binary==2.9.12
 
 openai==2.41.1
+litellm>=1.80.0,<1.87.0

--- a/api_service/services/llm/llm_service.py
+++ b/api_service/services/llm/llm_service.py
@@ -19,6 +19,12 @@ from typing import Any, Dict, List, Optional, Type, TypeVar
 from openai import AsyncOpenAI
 from pydantic import BaseModel, ValidationError
 
+try:
+    import litellm
+    _HAS_LITELLM = True
+except ImportError:
+    _HAS_LITELLM = False
+
 from api_service.config.logger_manager import LoggerManager
 from api_service.exceptions.api_exceptions import LLMValidationError
 from api_service.services.config_service import ConfigService
@@ -58,17 +64,33 @@ _RECOMMENDATION_SCHEMA_HINT = (
 
 def get_llm_client(user_id: Optional[int] = None) -> Optional[AsyncOpenAI]:
     """Initialize and return the OpenAI-compatible async client if configured.
-    
+
     Checks for user-specific OpenAI config first (if user_id provided and user has
     can_manage_ai permission), then falls back to global admin config.
 
+    When ``LLM_PROVIDER`` is ``litellm``, returns a sentinel object (not
+    ``None``) so callers know the LLM is configured.  Actual calls go through
+    :func:`_litellm_completion` instead of the returned client.
+
     :param user_id: Optional user ID to check for per-user OpenAI config
-    :return: Configured :class:`AsyncOpenAI` instance, or ``None`` when the
-        provider is not set up.
+    :return: Configured :class:`AsyncOpenAI` instance (or a sentinel when
+        using LiteLLM), or ``None`` when the provider is not set up.
     """
+    if _use_litellm():
+        config = ConfigService.get_runtime_config()
+        model = config.get("LLM_MODEL", "")
+        if not model:
+            logger.warning(
+                "LLM_PROVIDER is 'litellm' but LLM_MODEL is not set. "
+                "Set it to a litellm model string like 'anthropic/claude-sonnet-4-6'."
+            )
+            return None
+        logger.debug("Using LiteLLM provider with model %s", model)
+        return AsyncOpenAI(api_key="litellm-placeholder")
+
     api_key = None
     base_url = None
-    
+
     # Try to load user-specific config first
     if user_id is not None:
         try:
@@ -87,7 +109,7 @@ def get_llm_client(user_id: Optional[int] = None) -> Optional[AsyncOpenAI]:
                     logger.warning(f"Invalid JSON in user OpenAI config for user_id={user_id}")
         except Exception as e:
             logger.warning(f"Failed to load user OpenAI config for user_id={user_id}: {e}")
-    
+
     # Fall back to global config if no user-specific config
     if not api_key and not base_url:
         config = ConfigService.get_runtime_config()
@@ -116,6 +138,21 @@ def get_llm_client(user_id: Optional[int] = None) -> Optional[AsyncOpenAI]:
     except Exception as exc:
         logger.error("Failed to initialize OpenAI client: %s", exc)
         return None
+
+
+def _use_litellm() -> bool:
+    """Return True when LiteLLM provider is selected and the package is installed."""
+    config = ConfigService.get_runtime_config()
+    provider = config.get("LLM_PROVIDER", "openai")
+    if provider == "litellm":
+        if not _HAS_LITELLM:
+            logger.error(
+                "LLM_PROVIDER is set to 'litellm' but the litellm package is not installed. "
+                "Install it with: pip install litellm"
+            )
+            return False
+        return True
+    return False
 
 
 def is_llm_configured(config: Optional[Dict[str, Any]] = None) -> bool:
@@ -324,8 +361,28 @@ def _is_duplicate_of_history(rec_title: str, watched_titles: set) -> bool:
 # Core validation / retry engine
 # ---------------------------------------------------------------------------
 
+async def _litellm_completion(
+    model: str,
+    messages: List[Dict[str, str]],
+    **kwargs: Any,
+) -> Any:
+    """Call litellm.acompletion with drop_params enabled.
+
+    :param model: LiteLLM model string (e.g. ``"anthropic/claude-sonnet-4-6"``).
+    :param messages: Chat messages in OpenAI format.
+    :param kwargs: Additional kwargs forwarded to ``litellm.acompletion``.
+    :return: LiteLLM ModelResponse (OpenAI-compatible).
+    """
+    return await litellm.acompletion(
+        model=model,
+        messages=messages,
+        drop_params=True,
+        **kwargs,
+    )
+
+
 async def _call_with_validation(
-    client: AsyncOpenAI,
+    client: Optional[AsyncOpenAI],
     model: str,
     messages: List[Dict[str, str]],
     schema_cls: Type[_T],
@@ -350,7 +407,12 @@ async def _call_with_validation(
     reject a ``response_format`` with a 400 response fall back to JSON-object
     mode, then to plain prompting without burning a validation retry.
 
-    :param client: Initialised async OpenAI-compatible client.
+    When ``LLM_PROVIDER`` is ``litellm``, calls go through
+    :func:`_litellm_completion` (which uses ``litellm.acompletion`` with
+    ``drop_params=True``) instead of the OpenAI client.
+
+    :param client: Initialised async OpenAI-compatible client, or ``None``
+        when using the LiteLLM provider.
     :param model: Model identifier string (e.g. ``"gpt-4o-mini"``).
     :param messages: Chat messages in OpenAI format.
     :param schema_cls: Pydantic model class to validate against.
@@ -359,6 +421,7 @@ async def _call_with_validation(
     :raises LLMValidationError: When all attempts are exhausted.
     :return: Validated Pydantic model instance.
     """
+    use_litellm = _use_litellm()
     current_messages = list(messages)
     last_error: Exception = RuntimeError("No attempts made")
 
@@ -374,7 +437,10 @@ async def _call_with_validation(
                 request_kwargs["response_format"] = response_format
 
             try:
-                response = await client.chat.completions.create(**request_kwargs)
+                if use_litellm:
+                    response = await _litellm_completion(**request_kwargs)
+                else:
+                    response = await client.chat.completions.create(**request_kwargs)
                 break
             except Exception as exc:
                 if response_format is not None and _is_response_format_rejection(exc):
@@ -405,12 +471,10 @@ async def _call_with_validation(
                 "LLM response validation failed (attempt %d/%d): %s; response preview=%r",
                 attempt + 1,
                 max_retries + 1,
-                # Truncate to avoid leaking excessive content in logs.
                 str(exc)[:300],
                 preview,
             )
             if attempt < max_retries:
-                # Inject correction hint as the first system message and retry.
                 current_messages = [
                     {"role": "system", "content": _validation_retry_message(schema_cls)},
                     *messages,

--- a/api_service/test/test_llm_service.py
+++ b/api_service/test/test_llm_service.py
@@ -40,9 +40,11 @@ from api_service.services.llm.llm_service import (
     _deduplicate_history,
     _extract_json_object,
     _is_duplicate_of_history,
+    _litellm_completion,
     _normalize_title,
     _repair_title_qualifiers,
     _strip_markdown_fences,
+    _use_litellm,
     get_recommendations_from_history,
     interpret_search_query,
 )
@@ -625,6 +627,93 @@ class TestInterpretSearchQuery(unittest.IsolatedAsyncioTestCase):
         # Should not raise
         serialised = json.dumps(result)
         self.assertIsInstance(serialised, str)
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM provider integration
+# ---------------------------------------------------------------------------
+
+class TestUseLitellm(unittest.TestCase):
+
+    def test_returns_false_when_provider_is_openai(self):
+        config = {"LLM_PROVIDER": "openai"}
+        with patch("api_service.services.llm.llm_service.ConfigService.get_runtime_config", return_value=config):
+            self.assertFalse(_use_litellm())
+
+    def test_returns_false_when_provider_unset(self):
+        config = {}
+        with patch("api_service.services.llm.llm_service.ConfigService.get_runtime_config", return_value=config):
+            self.assertFalse(_use_litellm())
+
+    def test_returns_true_when_provider_is_litellm_and_installed(self):
+        config = {"LLM_PROVIDER": "litellm"}
+        with patch("api_service.services.llm.llm_service.ConfigService.get_runtime_config", return_value=config), \
+             patch("api_service.services.llm.llm_service._HAS_LITELLM", True):
+            self.assertTrue(_use_litellm())
+
+    def test_returns_false_when_litellm_not_installed(self):
+        config = {"LLM_PROVIDER": "litellm"}
+        with patch("api_service.services.llm.llm_service.ConfigService.get_runtime_config", return_value=config), \
+             patch("api_service.services.llm.llm_service._HAS_LITELLM", False):
+            self.assertFalse(_use_litellm())
+
+
+class TestLitellmCompletion(unittest.IsolatedAsyncioTestCase):
+
+    async def test_calls_litellm_acompletion_with_drop_params(self):
+        mock_response = _mock_openai_response('{"recommendations": []}')
+        with patch("api_service.services.llm.llm_service.litellm") as mock_litellm:
+            mock_litellm.acompletion = AsyncMock(return_value=mock_response)
+            result = await _litellm_completion(
+                model="anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "test"}],
+                temperature=0.7,
+            )
+            mock_litellm.acompletion.assert_called_once_with(
+                model="anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "test"}],
+                drop_params=True,
+                temperature=0.7,
+            )
+            self.assertEqual(result, mock_response)
+
+
+class TestCallWithValidationLitellm(unittest.IsolatedAsyncioTestCase):
+
+    async def test_routes_through_litellm_when_provider_set(self):
+        valid_payload = _wrap_recs([
+            {"title": "Interstellar", "year": 2014, "rationale": "Similar sci-fi.", "source_title": "Inception"}
+        ])
+        mock_response = _mock_openai_response(valid_payload)
+
+        with patch("api_service.services.llm.llm_service._use_litellm", return_value=True), \
+             patch("api_service.services.llm.llm_service._litellm_completion", new_callable=AsyncMock, return_value=mock_response):
+            result = await _call_with_validation(
+                client=None,
+                model="anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "test"}],
+                schema_cls=RecommendationList,
+            )
+            self.assertEqual(result.recommendations[0].title, "Interstellar")
+
+    async def test_uses_openai_client_when_provider_not_litellm(self):
+        valid_payload = _wrap_recs([
+            {"title": "Inception", "year": 2010, "rationale": "Mind-bending.", "source_title": "The Matrix"}
+        ])
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=_mock_openai_response(valid_payload)
+        )
+
+        with patch("api_service.services.llm.llm_service._use_litellm", return_value=False):
+            result = await _call_with_validation(
+                client=mock_client,
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "test"}],
+                schema_cls=RecommendationList,
+            )
+            mock_client.chat.completions.create.assert_called()
+            self.assertEqual(result.recommendations[0].title, "Inception")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add [LiteLLM](https://litellm.ai) as a native AI gateway provider. When `LLM_PROVIDER=litellm`, the app uses `litellm.acompletion()` to access 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Ollama, and more) directly - no proxy server needed.

Users just set `LLM_PROVIDER=litellm` and `LLM_MODEL=anthropic/claude-sonnet-4-6` with their provider API key. LiteLLM's `drop_params=True` silently drops provider-unsupported kwargs, fixing issues like #577 (Claude `top_k` error) automatically.

The frontend `SettingsAdvanced.vue` already documents LiteLLM proxy as a workaround, but this adds native backend support so users don't need to run a separate proxy server.

**Changes:**
- `api_service/services/llm/llm_service.py` - Added `_use_litellm()`, `_litellm_completion()` with `drop_params=True`, modified `_call_with_validation()` to route through litellm when configured
- `api_service/config/config.py` - Added `LLM_PROVIDER` config key (default: `openai`)
- `api_service/requirements.txt` - Added `litellm>=1.80.0,<1.87.0`
- `api_service/test/test_llm_service.py` - 7 new tests covering provider detection, `drop_params` forwarding, and routing

**Tests(55/55 tests pass):**
```
test/test_llm_service.py::TestUseLitellm::test_returns_false_when_provider_is_openai PASSED
test/test_llm_service.py::TestUseLitellm::test_returns_false_when_provider_unset PASSED
test/test_llm_service.py::TestUseLitellm::test_returns_true_when_provider_is_litellm_and_installed PASSED
test/test_llm_service.py::TestUseLitellm::test_returns_false_when_litellm_not_installed PASSED
test/test_llm_service.py::TestLitellmCompletion::test_calls_litellm_acompletion_with_drop_params PASSED
test/test_llm_service.py::TestCallWithValidationLitellm::test_routes_through_litellm_when_provider_set PASSED
test/test_llm_service.py::TestCallWithValidationLitellm::test_uses_openai_client_when_provider_not_litellm PASSED
55 passed in 0.24s
```

**Example usage:**
```yaml
# .env
LLM_PROVIDER=litellm
LLM_MODEL=anthropic/claude-sonnet-4-6
ANTHROPIC_API_KEY=sk-ant-...
```

## Checklist

- [x] Tests added/updated when applicable
- [ ] Documentation updated when behavior or setup changed
- [x] No hardcoded styles introduced
