### PR TITLE
Fix config import validation for Trakt media-user links

### DIFF
--- a/api_service/services/config_service.py
+++ b/api_service/services/config_service.py
@@ -60,6 +60,11 @@ _VALID_SETTING_KEYS: frozenset = (
 
 _LOG_SECRET_KEY_FRAGMENTS: tuple = ("token", "api_key", "password", "secret")
 
+_TRAKT_MISSING_TOKENS_ERROR = (
+    "Trakt OAuth tokens were not included in this config export. "
+    "Re-link the Trakt account."
+)
+
 
 def _sanitize_integration_config(service: str, config: dict) -> dict:
     """Return a copy of an integration config safe for global storage/export.
@@ -130,13 +135,16 @@ def _export_media_users(db: DatabaseManager, *, include_secrets: bool = False) -
 
 def _import_media_users(db: DatabaseManager, media_users: list) -> None:
     """Restore media-user identities and per-user Trakt data from a snapshot."""
+    if not isinstance(media_users, list):
+        raise ValueError('"media_users" must be a list')
+
     for entry in media_users:
         if not isinstance(entry, dict):
-            continue
+            raise ValueError('Each media user entry must be an object')
         provider = entry.get("provider")
         external_user_id = entry.get("external_user_id")
         if not provider or external_user_id is None:
-            continue
+            raise ValueError('Media user entries require provider and external_user_id')
 
         identity = db.upsert_media_user_identity(
             str(provider), str(external_user_id), entry.get("external_username"),
@@ -145,35 +153,64 @@ def _import_media_users(db: DatabaseManager, media_users: list) -> None:
         if not isinstance(trakt, dict):
             continue
 
+        token_source = trakt.get("token_source") or "manual_oauth"
+        requested_status = trakt.get("status") or "connected"
+        oauth = trakt.get("oauth_tokens")
+        imported_tokens_available = False
+        if isinstance(oauth, dict):
+            access_token = oauth.get("access_token")
+            refresh_token = oauth.get("refresh_token")
+            imported_tokens_available = bool(
+                access_token and refresh_token
+                and not is_redacted(access_token)
+                and not is_redacted(refresh_token)
+            )
+
+        existing_tokens_available = False
+        existing_link = db.get_trakt_account_link(identity["id"])
+        if existing_link:
+            existing_tokens_available = bool(db.get_trakt_oauth_tokens(existing_link["id"]))
+
+        status = requested_status
+        missing_manual_oauth_tokens = (
+            token_source == "manual_oauth"
+            and requested_status == "connected"
+            and not imported_tokens_available
+            and not existing_tokens_available
+        )
+        if missing_manual_oauth_tokens:
+            status = "error"
+
         link_id = db.upsert_trakt_account_link(
             media_user_identity_id=identity["id"],
             trakt_user_id=trakt.get("trakt_user_id"),
             trakt_username=trakt.get("trakt_username"),
-            token_source=trakt.get("token_source") or "manual_oauth",
-            status=trakt.get("status") or "connected",
+            token_source=token_source,
+            status=status,
         )
-        oauth = trakt.get("oauth_tokens")
-        if isinstance(oauth, dict):
-            access_token = oauth.get("access_token")
-            refresh_token = oauth.get("refresh_token")
-            if (
-                access_token and refresh_token
-                and not is_redacted(access_token)
-                and not is_redacted(refresh_token)
-            ):
-                db.upsert_trakt_oauth_tokens(
-                    link_id=link_id,
-                    access_token=access_token,
-                    refresh_token=refresh_token,
-                    expires_at=oauth.get("expires_at"),
-                )
-        for source in trakt.get("sources") or []:
+
+        if imported_tokens_available:
+            db.upsert_trakt_oauth_tokens(
+                link_id=link_id,
+                access_token=oauth.get("access_token"),
+                refresh_token=oauth.get("refresh_token"),
+                expires_at=oauth.get("expires_at"),
+            )
+        elif missing_manual_oauth_tokens:
+            db.mark_trakt_account_link_error(
+                identity["id"], "error", _TRAKT_MISSING_TOKENS_ERROR,
+            )
+
+        sources = trakt.get("sources") or []
+        if not isinstance(sources, list):
+            raise ValueError('Trakt sources must be a list')
+        for source in sources:
             if not isinstance(source, dict):
-                continue
+                raise ValueError('Each Trakt source entry must be an object')
             source_type = source.get("source_type")
             source_key = source.get("source_key")
             if not source_type or not source_key:
-                continue
+                raise ValueError('Trakt source entries require source_type and source_key')
             db.upsert_trakt_source(
                 media_user_identity_id=identity["id"],
                 source_type=source_type,
@@ -295,10 +332,34 @@ class ConfigService:
                 f"Expected {CURRENT_VERSION}."
             )
 
+        integrations = data.get("integrations") or {}
+        settings = data.get("settings") or {}
+        media_users = data.get("media_users") or []
+        if not isinstance(integrations, dict):
+            raise ValueError('"integrations" must be an object')
+        if not isinstance(settings, dict):
+            raise ValueError('"settings" must be an object')
+        if media_users and not isinstance(media_users, list):
+            raise ValueError('"media_users" must be a list')
+
         db = DatabaseManager()
 
-        # --- 1. Upsert integrations -------------------------------------------
-        integrations: dict = data.get("integrations") or {}
+        # --- 1. Restore settings ----------------------------------------------
+        if settings:
+            current_config = load_env_vars()
+            updated_keys = []
+            for key in _VALID_SETTING_KEYS:
+                if key in settings and not is_redacted(settings[key]):
+                    current_config[key] = settings[key]
+                    updated_keys.append(key)
+            logger.info("Restoring %d setting key(s) from import", len(updated_keys))
+            save_env_vars(current_config)
+
+        # Refresh DB config before DB-backed restores. Imported database
+        # settings must take effect before integrations/media users are written.
+        db.refresh_config()
+
+        # --- 2. Upsert integrations -------------------------------------------
         for service, service_cfg in integrations.items():
             if not isinstance(service_cfg, dict):
                 logger.warning(
@@ -313,23 +374,8 @@ class ConfigService:
             logger.info("Importing integration '%s' %s", service, safe)
             db.set_integration(service, service_cfg)
 
-        # --- 2. Restore settings ----------------------------------------------
-        settings: dict = data.get("settings") or {}
-        if settings:
-            current_config = load_env_vars()
-            updated_keys = []
-            for key in _VALID_SETTING_KEYS:
-                if key in settings and not is_redacted(settings[key]):
-                    current_config[key] = settings[key]
-                    updated_keys.append(key)
-            logger.info("Restoring %d setting key(s) from import", len(updated_keys))
-            save_env_vars(current_config)
-
         # --- 3. Restore media users (optional) --------------------------------
-        media_users = data.get("media_users") or []
         if media_users:
             _import_media_users(db, media_users)
 
-        # --- 4. Refresh DB config in case DB connection settings changed ------
-        db.refresh_config()
         logger.info("Config import completed successfully")

--- a/api_service/test/test_config.py
+++ b/api_service/test/test_config.py
@@ -576,6 +576,94 @@ class TestConfig(unittest.TestCase):
             except FileNotFoundError:
                 pass
 
+    def test_config_import_marks_redacted_trakt_link_unusable_without_existing_tokens(self):
+        import api_service.db.database_manager as dm_mod
+
+        real_db_cls = DatabaseManager
+        real_db_cls._instance = None
+        fd, db_file = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        path_patch = patch.object(dm_mod, 'DB_PATH', db_file)
+        env_patch = patch(
+            'api_service.db.database_manager.load_env_vars',
+            return_value={'DB_TYPE': 'sqlite'},
+        )
+        config_db_patch = patch(
+            'api_service.services.config_service.DatabaseManager',
+            real_db_cls,
+        )
+        path_patch.start()
+        env_patch.start()
+        config_db_patch.start()
+
+        try:
+            manager = real_db_cls()
+
+            config_service.ConfigService.import_config({
+                'version': config_service.CURRENT_VERSION,
+                'integrations': {},
+                'settings': {},
+                'media_users': [{
+                    'provider': 'jellyfin',
+                    'external_user_id': 'jf-1',
+                    'external_username': 'alice',
+                    'trakt': {
+                        'trakt_user_id': 't-1',
+                        'trakt_username': 'trakt_alice',
+                        'token_source': 'manual_oauth',
+                        'status': 'connected',
+                        'oauth_tokens': {
+                            'access_token': '***',
+                            'refresh_token': '***',
+                            'expires_at': None,
+                        },
+                    },
+                }],
+            })
+
+            identity = manager.get_media_user_identity('jellyfin', 'jf-1')
+            link = manager.get_trakt_account_link(identity['id'])
+            self.assertFalse(link['connected'])
+            self.assertEqual(link['status'], 'error')
+            self.assertIn('OAuth tokens were not included', link['last_error'])
+            self.assertIsNone(manager.get_trakt_oauth_tokens(link['id']))
+        finally:
+            real_db_cls._instance = None
+            config_db_patch.stop()
+            env_patch.stop()
+            path_patch.stop()
+            try:
+                os.unlink(db_file)
+            except FileNotFoundError:
+                pass
+
+    def test_config_import_refreshes_database_before_restoring_media_users(self):
+        db = MagicMock()
+        call_order = []
+        db.get_integration.return_value = {}
+        db.set_integration.side_effect = lambda *args, **kwargs: call_order.append('set_integration')
+        db.refresh_config.side_effect = lambda *args, **kwargs: call_order.append('refresh_config')
+        db.upsert_media_user_identity.side_effect = lambda *args, **kwargs: call_order.append('media_user') or {'id': 10}
+
+        self._db_manager_cls.return_value = db
+
+        with patch('api_service.services.config_service.load_env_vars', return_value={'DB_TYPE': 'sqlite'}), \
+                patch('api_service.services.config_service.save_env_vars'):
+            config_service.ConfigService.import_config({
+                'version': config_service.CURRENT_VERSION,
+                'integrations': {'trakt': {'client_id': 'cid', 'client_secret': 'secret'}},
+                'settings': {'DB_TYPE': 'sqlite'},
+                'media_users': [{
+                    'provider': 'jellyfin',
+                    'external_user_id': 'jf-1',
+                    'external_username': 'alice',
+                }],
+            })
+
+        self.assertLess(call_order.index('refresh_config'), call_order.index('set_integration'))
+        self.assertLess(call_order.index('refresh_config'), call_order.index('media_user'))
+
     def test_config_export_import_media_users_roundtrip(self):
         import api_service.db.database_manager as dm_mod
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -686,7 +686,7 @@ Import merges the snapshot into the running instance:
 - If you import a safe export on an instance that already has credentials, existing secrets are preserved.
 - A full backup import restores credentials and Trakt tokens without re-linking.
 
-After importing a safe export, Trakt links may still show as connected in metadata, but Trakt features will not work until each user links Trakt again unless the import included live OAuth tokens.
+After importing a safe export on a fresh instance, Trakt links without live OAuth tokens are marked as needing re-linking. Trakt features will not work for those users until each user links Trakt again, unless the import included live OAuth tokens or the target instance already had matching tokens.
 
 #### Recommended flow
 


### PR DESCRIPTION
## Summary

This fixes a config import state bug around media users and Trakt account links.

Previously, a config import could restore a Trakt account link as `connected` even when the export did not include per-user OAuth tokens. That happens with normal redacted exports. The UI/job layer could then see a linked Trakt user, but the Trakt job had no usable tokens and failed unclearly during startup or execution.

The import path also restored media users before refreshing database settings from the imported config. If the import changed DB connection settings, media users and Trakt links could be written to the old DB connection and then appear missing after refresh.

## What Changed

- Validate imported `integrations`, `settings`, `media_users`, and Trakt source structures instead of silently accepting malformed data.
- Restore settings and refresh DB config before writing integrations or media-user/Trakt rows.
- When importing a redacted Trakt OAuth link with no existing local tokens, mark the link as `error` instead of `connected`.
- Preserve existing local Trakt tokens when importing a redacted backup over an already-linked account.
- Document the safe-export re-link behavior in the installation guide.
- Add regression tests for:
  - Redacted Trakt tokens on fresh import.
  - DB refresh ordering before restoring media users.

## Why

A redacted config export cannot fully restore a Trakt account because the per-user OAuth tokens are intentionally omitted. Import should make that state explicit and require re-linking, not create a connected-looking account that cannot run jobs.

## Test Plan

- [x] `cd api_service && python -m pytest -q`

Result:

- `842 passed in 45.34s`

## Pull Request Checklist

- [x] Tests added/updated when applicable
- [x] Documentation updated when behavior or setup changed
- [x] No hardcoded styles introduced
