### PR TITLE
fix: avoid KeyError in save_user when the media user has no name

### DIFF
--- a/api_service/db/components/request_mixin.py
+++ b/api_service/db/components/request_mixin.py
@@ -34,13 +34,17 @@ class RequestMixin:
     
     def save_user(self, user: Dict[str, Any]) -> None:
         """Save a new user to the database, ignoring duplicates."""
-        self.logger.debug(f"Saving user: {user['id']} {user['name']}")
-        
+        # Some callers (e.g. the Trakt recommendations job) only have the media
+        # user id available, not the display name. Fall back to the id so a
+        # missing 'name' key never raises KeyError and aborts the request.
+        user_name = user.get('name') or user['id']
+        self.logger.debug(f"Saving user: {user['id']} {user_name}")
+
         query = """
             INSERT OR IGNORE INTO users (user_id, user_name)
             VALUES (?, ?)
         """
-        params = (user['id'], user['name'])
+        params = (user['id'], user_name)
         
         with self.get_connection() as conn:
             cursor = conn.cursor()

--- a/api_service/test/test_request_sources.py
+++ b/api_service/test/test_request_sources.py
@@ -108,3 +108,29 @@ def test_pending_requests_filter_by_requested_for_user(tmp_path):
     DatabaseManager._instance = None
     assert total == 1
     assert items[0]["media_user_id"] == "plex-1"
+
+
+def test_save_user_without_name_falls_back_to_id(tmp_path):
+    """Regression: the Trakt recommendations job calls save_user with only an
+    'id' (no display name). save_user must not raise KeyError on 'name'."""
+    db_file = str(tmp_path / "requests.db")
+    with (
+        patch.object(dm_mod, "DB_PATH", db_file),
+        patch("api_service.db.database_manager.load_env_vars", return_value={"DB_TYPE": "sqlite"}),
+    ):
+        DatabaseManager._instance = None
+        db = DatabaseManager()
+
+        # Must not raise even though 'name' is absent.
+        db.save_user({"id": "trakt-user-1"})
+
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT user_name FROM users WHERE user_id = ?", ("trakt-user-1",)
+            )
+            row = cursor.fetchone()
+
+    DatabaseManager._instance = None
+    assert row is not None
+    assert row[0] == "trakt-user-1"  # falls back to the id when name is missing


### PR DESCRIPTION
## Summary

Creating a **Trakt Recommendations** job and running it (not dry-run) never requests anything. For every recommended title the log shows:

```
TraktRecommendationsAutomation - ERROR - Error processing <title>: 'name'
```

The job reports "Fetched N Trakt recommendations after filtering" but ends up creating 0 requests. Dry-run previews work fine, which is what hid it at first.

### Cause

`TraktRecommendationsAutomation` calls `request_media` with a media user that only carries an id — the display name isn't available at that point:

```python
user={"id": str(self.job_data["user_ids"][0])}
```

`request_media` then calls `db.save_user(user)`, which reads `user['name']` directly:

```python
self.logger.debug(f"Saving user: {user['id']} {user['name']}")
...
params = (user['id'], user['name'])
```

That raises `KeyError: 'name'`, and the per-item `try/except` reports it as `Error processing <title>: 'name'`. The regular `recommendation` job passes a full user dict (id + name) so it's unaffected, and dry-run runs go through `_format_dry_run_item` (which uses `.get`) and never reach `save_user` — hence previews succeed while real runs request nothing.

### Fix

Fall back to the user id when `name` is missing, so a media user without a display name can't crash the request path.

### Testing

```
pytest api_service/test/test_request_sources.py -q
7 passed
```

## Checklist

- [x] Tests added/updated when applicable
- [x] Documentation updated when behavior or setup changed (n/a — bug fix)
- [x] No hardcoded styles introduced (backend-only change)
