### PR TITLE
Nightly

### DIFF
--- a/api_service/config/config.py
+++ b/api_service/config/config.py
@@ -143,6 +143,9 @@ def load_env_vars(force_reload: bool = False):
         # Parse JSON string fields
         resolved_config = _parse_json_fields(resolved_config)
         resolved_config = merge_db_integrations_into_flat(resolved_config)
+        # Configs created before the setup flag existed are complete when their required values are.
+        if 'SETUP_COMPLETED' not in config_data:
+            resolved_config['SETUP_COMPLETED'] = is_setup_complete(resolved_config)
         with _CONFIG_CACHE_LOCK:
             _CONFIG_CACHE = copy.deepcopy(resolved_config)
         return copy.deepcopy(resolved_config)

--- a/api_service/db/components/request_mixin.py
+++ b/api_service/db/components/request_mixin.py
@@ -34,13 +34,17 @@ class RequestMixin:
     
     def save_user(self, user: Dict[str, Any]) -> None:
         """Save a new user to the database, ignoring duplicates."""
-        self.logger.debug(f"Saving user: {user['id']} {user['name']}")
-        
+        # Some callers (e.g. the Trakt recommendations job) only have the media
+        # user id available, not the display name. Fall back to the id so a
+        # missing 'name' key never raises KeyError and aborts the request.
+        user_name = user.get('name') or user['id']
+        self.logger.debug(f"Saving user: {user['id']} {user_name}")
+
         query = """
             INSERT OR IGNORE INTO users (user_id, user_name)
             VALUES (?, ?)
         """
-        params = (user['id'], user['name'])
+        params = (user['id'], user_name)
         
         with self.get_connection() as conn:
             cursor = conn.cursor()

--- a/api_service/services/jellyfin/jellyfin_client.py
+++ b/api_service/services/jellyfin/jellyfin_client.py
@@ -343,7 +343,10 @@ class JellyfinClient(BaseHTTPClient):
                     return {}
 
                 data = await response.json()
-                provider_ids = data.get("ProviderIds") or {}
+                items = data.get("Items") or []
+                provider_ids = data.get("ProviderIds") or (
+                    (items[0].get("ProviderIds") or {}) if items else {}
+                )
                 self._series_provider_ids_cache[series_id] = provider_ids
                 return provider_ids
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:

--- a/api_service/test/test_config.py
+++ b/api_service/test/test_config.py
@@ -863,3 +863,14 @@ class TestConfig(unittest.TestCase):
         save_env_vars(config)
         result = is_setup_complete(None)
         self.assertTrue(result)
+
+    def test_load_env_vars_marks_complete_legacy_config_as_setup_complete(self):
+        legacy_config = {
+            'TMDB_API_KEY': 'key', 'SELECTED_SERVICE': 'plex',
+            'PLEX_TOKEN': 'tok', 'PLEX_API_URL': 'http://plex',
+            'DB_TYPE': 'sqlite',
+        }
+        with open(self._tmp.name, 'w', encoding='utf-8') as config_file:
+            yaml.safe_dump(legacy_config, config_file)
+
+        self.assertTrue(load_env_vars(force_reload=True)['SETUP_COMPLETED'])

--- a/api_service/test/test_jellyfin_client.py
+++ b/api_service/test/test_jellyfin_client.py
@@ -454,7 +454,9 @@ class TestGetSeriesProviderIds(unittest.IsolatedAsyncioTestCase):
         self.client = _make_client()
 
     async def test_returns_parent_series_provider_ids(self):
-        resp = _mock_response(200, {'ProviderIds': {'Tmdb': '1418'}})
+        resp = _mock_response(200, {
+            'Items': [{'ProviderIds': {'Tmdb': '1418'}}],
+        })
         session = _mock_session(resp)
 
         with patch.object(self.client, '_get_session', AsyncMock(return_value=session)):

--- a/api_service/test/test_request_sources.py
+++ b/api_service/test/test_request_sources.py
@@ -108,3 +108,29 @@ def test_pending_requests_filter_by_requested_for_user(tmp_path):
     DatabaseManager._instance = None
     assert total == 1
     assert items[0]["media_user_id"] == "plex-1"
+
+
+def test_save_user_without_name_falls_back_to_id(tmp_path):
+    """Regression: the Trakt recommendations job calls save_user with only an
+    'id' (no display name). save_user must not raise KeyError on 'name'."""
+    db_file = str(tmp_path / "requests.db")
+    with (
+        patch.object(dm_mod, "DB_PATH", db_file),
+        patch("api_service.db.database_manager.load_env_vars", return_value={"DB_TYPE": "sqlite"}),
+    ):
+        DatabaseManager._instance = None
+        db = DatabaseManager()
+
+        # Must not raise even though 'name' is absent.
+        db.save_user({"id": "trakt-user-1"})
+
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT user_name FROM users WHERE user_id = ?", ("trakt-user-1",)
+            )
+            row = cursor.fetchone()
+
+    DatabaseManager._instance = None
+    assert row is not None
+    assert row[0] == "trakt-user-1"  # falls back to the id when name is missing

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -161,6 +161,11 @@ export const updateTraktSource = (provider, externalUserId, payload) =>
 
 export const getMyTraktStatus = () => axios.get('/api/trakt/me');
 
+export const listTraktJobUsers = async (role) => {
+    const response = role === 'user' ? await getMyTraktStatus() : await listTraktMediaUsers();
+    return response.data?.media_users || (response.data?.media_user ? [response.data.media_user] : []);
+};
+
 export const startMyTraktDeviceCode = () => axios.post('/api/trakt/me/device/code');
 
 export const pollMyTraktDeviceToken = (deviceCode) =>

--- a/client/src/api/api.test.js
+++ b/client/src/api/api.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import axios from 'axios';
+import { listTraktJobUsers } from './api.js';
+
+test('Trakt job users are scoped by role', async () => {
+  const originalAdapter = axios.defaults.adapter;
+  const requested = [];
+  axios.defaults.adapter = async (config) => {
+    requested.push(config.url);
+    const mediaUser = { external_user_id: 'mine', trakt: { connected: true } };
+    return {
+      data: config.url === '/api/trakt/me' ? { media_user: mediaUser } : { media_users: [mediaUser] },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    };
+  };
+
+  try {
+    assert.deepEqual(await listTraktJobUsers('user'), [
+      { external_user_id: 'mine', trakt: { connected: true } },
+    ]);
+    assert.equal((await listTraktJobUsers('admin')).length, 1);
+    assert.deepEqual(requested, ['/api/trakt/me', '/api/trakt/media-users']);
+  } finally {
+    axios.defaults.adapter = originalAdapter;
+  }
+});

--- a/client/src/components/settings/jobs/JobModal.vue
+++ b/client/src/components/settings/jobs/JobModal.vue
@@ -277,7 +277,7 @@ import RecommendationFilters from './RecommendationFilters.vue';
 import TraktRecommendationFilters from './TraktRecommendationFilters.vue';
 import SchedulePicker from './SchedulePicker.vue';
 import { jobsApi } from '@/api/jobsApi';
-import { listTraktMediaUsers } from '@/api/api';
+import { listTraktJobUsers } from '@/api/api';
 import { waitForAuthReady, useAuth } from '@/composables/useAuth';
 import { getJobTypeIcon } from '@/utils/jobTypeVisuals.js';
 import axios from 'axios';
@@ -473,8 +473,8 @@ export default {
           this.connectedUsers = [];
           return;
         }
-        const traktRes = await listTraktMediaUsers();
-        this.connectedUsers = (traktRes.data?.media_users || [])
+        const traktUsers = await listTraktJobUsers(this.currentUser?.role);
+        this.connectedUsers = traktUsers
           .filter((user) => user.trakt?.connected);
       } catch {
         this.traktConfigured = false;


### PR DESCRIPTION
# Improve Jellyfin Compatibility, Configuration Migration, and Trakt Infrastructure

This release improves Jellyfin compatibility, enhances migration behavior for existing installations, and introduces internal infrastructure for future Trakt job improvements.

## 🎬 Jellyfin

* Fixed provider ID retrieval for Jellyfin media items with empty provider mappings #404


## ⚙️ Configuration

* Automatically mark legacy configurations as setup complete during migration, improving upgrade compatibility #405


## 🔄 Trakt Infrastructure

* Added internal `listTraktJobUsers` support for role-based media user retrieval #406
* Added backend test coverage for role-based Trakt user retrieval


## 🛠 Fixes

* Fixed a `KeyError` when saving media users without a display name #407


## 🧪 Testing

* Expanded backend test coverage for Trakt job user retrieval
* Added regression tests for media users without names


## 🧹 Misc

* General maintenance and stability improvements