### PR TITLE
docs: add OrcaRouter to supported providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The engine works with **any OpenAI-compatible API**, so you can use a cloud prov
 | **OpenAI** | Required (`sk-proj-...`) | *(leave blank)* | `gpt-4o-mini` |
 | **Ollama** (local) | Not required | `http://localhost:11434/v1` | `mistral`, `llama3` |
 | **OpenRouter** | Required (`sk-or-v1-...`) | `https://openrouter.ai/api/v1` | `meta-llama/llama-3-8b-instruct` |
+| **OrcaRouter** | Required (`sk-orca-...`) | `https://api.orcarouter.ai/v1` | `openai/gpt-5.5` |
 | **LiteLLM Proxy** | Depends on config | `http://<your-proxy>:4000` | Depends on config |
 
 **Note for Ollama users:** make sure Ollama is running and the model is pulled (`ollama pull mistral`) before saving. The API Key field can be left blank — SuggestArr will use a placeholder automatically.


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a supported provider in the AI Recommendations "Supported providers" table, mirroring the existing OpenRouter row. The LLM engine already works with any OpenAI-compatible API, so this documents the OrcaRouter endpoint as a drop-in cloud option.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Checklist

- [x] Documentation updated when behavior or setup changed (README provider table only)

I'm an engineer on the OrcaRouter team.
